### PR TITLE
Add GitHub Actions to map the existing GitLab CI/CD config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,67 @@
-name: hello-world
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "CI"
 on: [push, pull_request]
 
 jobs:
-  hello:
-    runs-on: ubuntu-22.04
+  build-dev-image:
+    env:
+      IMAGE: "${{ vars.image_registry }}"
+      IMAGE_TAG: "${{ github.sha }}"
+      BUILDIMAGE: "${{ vars.image_registry }}/build:${{ github.sha }}"
     steps:
-    - name: say-hello
-      run: echo "Hello World!"
+    - name: build-dev-image
+      run:
+      - apk --no-cache add make bash
+      - make .build-image
+      - docker login -u "${{ vars.image_registry_user }}" -p "${{ secrets.image_registry_password }}" "${{ vars.image_registry }}"
+      - make .push-build-image
+    - name: return-image-name
+      run:
+      - echo "image=${BUILDIMAGE}" >> "${GITHUB_OUTPUT}"
+    outputs:
+      image: ${{ steps.return-image-name.outputs.image }}
+  go-checks:
+    needs: build-dev-image
+    runs:
+      using: docker
+      image: ${{needs.build-dev-image.outputs.image}}
+    steps:
+    - name: fmt
+      run: make assert-fmt
+    - name: vet
+      run: make vet
+    - name: lint
+      run: make lint
+    - name: ineffassign
+      run: make ineffassign
+    - name: misspell
+      run: make misspell
+  go-build:
+    needs: go-checks
+    runs:
+      using: docker
+      image: ${{needs.build-dev-image.outputs.image}}
+    steps:
+    - name: build
+      run: make build
+  unit-tests:
+    needs: go-build
+    runs:
+      using: docker
+      image: ${{needs.build-dev-image.outputs.image}}
+    steps:
+    - name: unit-tests
+      run: make test


### PR DESCRIPTION
As part of fully migrating https://gitlab.com/nvidia/cloud-native/k8s-operator-libs to GitHub, we need to ensure that CI is running like it used to be. To do that, we move the implementation from GitLab to GitHub.

In a later PR, after syncing is stopped, we will remove the following files completely:
* https://github.com/NVIDIA/k8s-operator-libs/blob/main/.common-ci.yml
* https://github.com/NVIDIA/k8s-operator-libs/blob/main/.gitlab-ci.yml
* https://github.com/NVIDIA/k8s-operator-libs/blob/main/.nvidia-ci.yml