### PR TITLE
enable NV GHA runners - Step 1

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,2 @@
+# https://docs.gha-runners.nvidia.com/apps/copy-pr-bot/#configuration
+enabled: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 name: "CI"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
This PR is the first step in enabling the Nvidia managed GitHub runners for this repo. 

Here, we enable the `copy-pr-bot` which triggers CI builds for a given PR. The copy PR bot creates a copy of the PR branch with the format `pull-request[0-9]+` which in turn kicks off a new GitHub Actions CI pipeline job.

The copy PR bot has already been tested and run successfully in other projects:

- https://github.com/NVIDIA/gpu-operator/tree/main/.github
- https://github.com/NVIDIA/k8s-device-plugin/tree/main/.github
- https://github.com/NVIDIA/gpu-driver-container/tree/main/.github

and many more


Go [here](https://docs.gha-runners.nvidia.com/) to learn more about the NVIDIA GitHub Action runners