### PR TITLE
fix(event): fix event display problem

### DIFF
--- a/pkg/upgrade/drain_manager.go
+++ b/pkg/upgrade/drain_manager.go
@@ -112,7 +112,7 @@ func (m *DrainManagerImpl) ScheduleNodesDrain(ctx context.Context, drainConfig *
 					m.log.V(consts.LogLevelError).Error(err, "Failed to cordon node", "node", node.Name)
 					_ = m.nodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, node, UpgradeStateFailed)
 					logEventf(m.eventRecorder, node, corev1.EventTypeWarning, GetEventReason(),
-						"Failed to cordon the node, %s", err.Error())
+						fmt.Sprintf("Failed to cordon the node, %s", err.Error()))
 					return
 				}
 				m.log.V(consts.LogLevelInfo).Info("Cordoned the node", "node", node.Name)
@@ -122,7 +122,7 @@ func (m *DrainManagerImpl) ScheduleNodesDrain(ctx context.Context, drainConfig *
 					m.log.V(consts.LogLevelError).Error(err, "Failed to drain node", "node", node.Name)
 					_ = m.nodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, node, UpgradeStateFailed)
 					logEventf(m.eventRecorder, node, corev1.EventTypeWarning, GetEventReason(),
-						"Failed to drain the node, %s", err.Error())
+						fmt.Sprintf("Failed to drain the node, %s", err.Error()))
 					return
 				}
 				m.log.V(consts.LogLevelInfo).Info("Drained the node", "node", node.Name)

--- a/pkg/upgrade/node_upgrade_state_provider.go
+++ b/pkg/upgrade/node_upgrade_state_provider.go
@@ -85,7 +85,7 @@ func (p *NodeUpgradeStateProviderImpl) ChangeNodeUpgradeState(
 			"node", node,
 			"state", newNodeState)
 		logEventf(p.eventRecorder, node, corev1.EventTypeWarning, GetEventReason(),
-			"Failed to update node state label to %s, %s", newNodeState, err.Error())
+			fmt.Sprintf("Failed to update node state label to %s, %s", newNodeState, err.Error()))
 		return err
 	}
 
@@ -121,13 +121,13 @@ func (p *NodeUpgradeStateProviderImpl) ChangeNodeUpgradeState(
 			"node", node,
 			"state", newNodeState)
 		logEventf(p.eventRecorder, node, corev1.EventTypeWarning, GetEventReason(),
-			"Failed to update node state label to %s, %s", newNodeState, err.Error())
+			fmt.Sprintf("Failed to update node state label to %s, %s", newNodeState, err.Error()))
 	} else {
 		p.Log.V(consts.LogLevelInfo).Info("Successfully changed node upgrade state label",
 			"node", node.Name,
 			"new state", newNodeState)
 		logEventf(p.eventRecorder, node, corev1.EventTypeNormal, GetEventReason(),
-			"Successfully updated node state label to %s", newNodeState)
+			fmt.Sprintf("Successfully updated node state label to %s", newNodeState))
 	}
 
 	return err
@@ -156,7 +156,7 @@ func (p *NodeUpgradeStateProviderImpl) ChangeNodeUpgradeAnnotation(
 			"annotationKey", key,
 			"annotationValue", value)
 		logEventf(p.eventRecorder, node, corev1.EventTypeWarning, GetEventReason(),
-			"Failed to update node annotation %s=%s: %s", key, value, err.Error())
+			fmt.Sprintf("Failed to update node annotation %s=%s: %s", key, value, err.Error()))
 		return err
 	}
 
@@ -202,14 +202,14 @@ func (p *NodeUpgradeStateProviderImpl) ChangeNodeUpgradeAnnotation(
 			"annotationKey", key,
 			"annotationValue", value)
 		logEventf(p.eventRecorder, node, corev1.EventTypeWarning, GetEventReason(),
-			"Failed to update node annotation to %s=%s: %s", key, value, err.Error())
+			fmt.Sprintf("Failed to update node annotation to %s=%s: %s", key, value, err.Error()))
 	} else {
 		p.Log.V(consts.LogLevelInfo).Info("Successfully changed node upgrade state annotation",
 			"node", node.Name,
 			"annotationKey", key,
 			"annotationValue", value)
 		logEventf(p.eventRecorder, node, corev1.EventTypeNormal, GetEventReason(),
-			"Successfully updated node annotation to %s=%s", key, value)
+			fmt.Sprintf("Successfully updated node annotation to %s=%s", key, value))
 	}
 
 	return err

--- a/pkg/upgrade/pod_manager.go
+++ b/pkg/upgrade/pod_manager.go
@@ -214,7 +214,7 @@ func (m *PodManagerImpl) SchedulePodEviction(ctx context.Context, config *PodMan
 				if err != nil {
 					m.log.V(consts.LogLevelError).Error(err, "Failed to delete pods on the node", "node", node.Name)
 					logEventf(m.eventRecorder, &node, corev1.EventTypeWarning, GetEventReason(),
-						"Failed to delete workload pods on the node for the driver upgrade, %s", err.Error())
+						fmt.Sprintf("Failed to delete workload pods on the node for the driver upgrade, %s", err.Error()))
 					m.updateNodeToDrainOrFailed(ctx, node, config.DrainEnabled)
 					return
 				}
@@ -246,7 +246,7 @@ func (m *PodManagerImpl) SchedulePodsRestart(ctx context.Context, pods []*corev1
 		if err != nil {
 			m.log.V(consts.LogLevelInfo).Error(err, "Failed to delete pod", "pod", pod.Name)
 			logEventf(m.eventRecorder, pod, corev1.EventTypeWarning, GetEventReason(),
-				"Failed to restart driver pod %s", err.Error())
+				fmt.Sprintf("Failed to restart driver pod %s", err.Error()))
 			return err
 		}
 	}
@@ -294,7 +294,7 @@ func (m *PodManagerImpl) ScheduleCheckOnPodCompletion(ctx context.Context, confi
 					err = m.HandleTimeoutOnPodCompletions(ctx, &node, int64(config.WaitForCompletionSpec.TimeoutSecond))
 					if err != nil {
 						logEventf(m.eventRecorder, &node, corev1.EventTypeWarning, GetEventReason(),
-							"Failed to handle timeout for job completions, %s", err.Error())
+							fmt.Sprintf("Failed to handle timeout for job completions, %s", err.Error()))
 						return
 					}
 				}
@@ -305,7 +305,7 @@ func (m *PodManagerImpl) ScheduleCheckOnPodCompletion(ctx context.Context, confi
 			err = m.nodeUpgradeStateProvider.ChangeNodeUpgradeAnnotation(ctx, &node, annotationKey, "null")
 			if err != nil {
 				logEventf(m.eventRecorder, &node, corev1.EventTypeWarning, GetEventReason(),
-					"Failed to remove annotation used to track job completions: %s", err.Error())
+					fmt.Sprintf("Failed to remove annotation used to track job completions: %s", err.Error()))
 				return
 			}
 			// update node state

--- a/pkg/upgrade/validation_manager.go
+++ b/pkg/upgrade/validation_manager.go
@@ -97,7 +97,7 @@ func (m *ValidationManagerImpl) Validate(ctx context.Context, node *corev1.Node)
 			err = m.handleTimeout(ctx, node, int64(validationTimeoutSeconds))
 			if err != nil {
 				logEventf(m.eventRecorder, node, corev1.EventTypeWarning, GetEventReason(),
-					"Failed to handle timeout for validation state", err.Error())
+					fmt.Sprintf("Failed to handle timeout for validation state: %s", err.Error()))
 				return false, fmt.Errorf("unable to handle timeout for validation state: %v", err)
 			}
 			done = false


### PR DESCRIPTION


```bash
root@VM-0-9-ubuntu:/home/ubuntu# kubectl  get event
LAST SEEN   TYPE     REASON                    OBJECT                                      MESSAGE
...
50m         Normal   NodeHasSufficientPID      node/k8s-dra-driver-cluster-worker          Node k8s-dra-driver-cluster-worker status is now: NodeHasSufficientPID
50m         Normal   NodeAllocatableEnforced   node/k8s-dra-driver-cluster-worker          Updated Node Allocatable limit across pods
50m         Normal   RegisteredNode            node/k8s-dra-driver-cluster-worker          Node k8s-dra-driver-cluster-worker event: Registered Node k8s-dra-driver-cluster-worker in Controller
50m         Normal   Starting                  node/k8s-dra-driver-cluster-worker
50m         Normal   NodeReady                 node/k8s-dra-driver-cluster-worker          Node k8s-dra-driver-cluster-worker status is now: NodeReady
48m         Normal   GPUDriverUpgrade          node/k8s-dra-driver-cluster-worker          Successfully updated node state label to [upgrade-done]%!(EXTRA <nil>)


root@VM-0-9-ubuntu:/home/ubuntu# kubectl logs -f gpu-operator-64bdf76697-8d8kr -ngpu-operator | grep "Successfully "
{"level":"info","ts":1733661826.0248199,"logger":"controllers.Upgrade","msg":"Successfully changed node upgrade state label","node":"k8s-dra-driver-cluster-worker","new state":"upgrade-done"}

```