### PR TITLE
run go mod tidy to sync gomod artifacts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/NVIDIA/k8s-operator-libs
 
-go 1.22.0
+go 1.23.0
+
 toolchain go1.23.4
 
 require (


### PR DESCRIPTION
This fixes the CI failures introduced by https://github.com/NVIDIA/k8s-operator-libs/pull/65

Looks like we need to ensure copy-pr-bot triggers the CI checks before merging

UPDATE: We need to enable `copy-pr-bot` as an Integrated App in the repository settings. I don't have admin access to this repo, unfortunately. @cdesiniotis or @adrianchiris Are you able to do this? 