### PR TITLE
fix bug in the logEventf method

### DIFF
--- a/pkg/upgrade/util.go
+++ b/pkg/upgrade/util.go
@@ -141,7 +141,7 @@ func GetEventReason() string {
 func logEventf(recorder record.EventRecorder, object runtime.Object, eventType string, reason string, messageFmt string,
 	args ...interface{}) {
 	if recorder != nil {
-		recorder.Eventf(object, eventType, reason, messageFmt, args, nil)
+		recorder.Eventf(object, eventType, reason, messageFmt, args...)
 	}
 }
 


### PR DESCRIPTION
This PR fixes a regression introduced in #11. It looks like the `nil` param was added to the variadic param to satisfy the `asasalint` linter. 

The right fix for this lint issue is to forward the variadic argument `args` as a variadic argument instead of a slice