### PR TITLE
feat: adding requestor upgrade mode

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -104,7 +104,7 @@ linters-settings:
     threshold: 100
   funlen:
     lines: 120
-    statements: 55
+    statements: 58
   goconst:
     min-len: 2
     min-occurrences: 2

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.4
 
 require (
+	github.com/Mellanox/maintenance-operator/api v0.1.1
 	github.com/go-logr/logr v1.4.2
 	github.com/onsi/ginkgo/v2 v2.23.0
 	github.com/onsi/gomega v1.36.2

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/Mellanox/maintenance-operator/api v0.1.1 h1:DSPE7SS9DmieddjZtiL7eA5yCnYm9UkwRo1ViJtixoc=
+github.com/Mellanox/maintenance-operator/api v0.1.1/go.mod h1:5OIBO4beWexC3JvLIH1GGNzr49QW7UoZe2LgT/IXYIc=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/hack/crd/bases/maintenance.nvidia.com_nodemaintenances.yaml
+++ b/hack/crd/bases/maintenance.nvidia.com_nodemaintenances.yaml
@@ -1,0 +1,285 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: nodemaintenances.maintenance.nvidia.com
+spec:
+  group: maintenance.nvidia.com
+  names:
+    kind: NodeMaintenance
+    listKind: NodeMaintenanceList
+    plural: nodemaintenances
+    singular: nodemaintenance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.nodeName
+      name: Node
+      type: string
+    - jsonPath: .spec.requestorID
+      name: Requestor
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Phase
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Failed')].reason
+      name: Failed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NodeMaintenance is the Schema for the nodemaintenances API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodeMaintenanceSpec defines the desired state of NodeMaintenance
+            properties:
+              additionalRequestors:
+                description: |-
+                  AdditionalRequestors is a set of additional requestor IDs which are using the same NodeMaintenance
+                  request. addition or removal of requiestor IDs to this list MUST be made with update operation (and retry on failure)
+                  which will replace the entire list.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              cordon:
+                default: true
+                description: Cordon if set, marks node as unschedulable during maintenance
+                  operation
+                type: boolean
+              drainSpec:
+                description: DrainSpec specifies how a node will be drained. if not
+                  provided, no draining will be performed.
+                properties:
+                  deleteEmptyDir:
+                    default: false
+                    description: |-
+                      DeleteEmptyDir indicates if should continue even if there are pods using emptyDir
+                      (local data that will be deleted when the node is drained)
+                    type: boolean
+                  force:
+                    default: false
+                    description: Force draining even if there are pods that do not
+                      declare a controller
+                    type: boolean
+                  podEvictionFilters:
+                    description: |-
+                      PodEvictionFilters specifies filters for pods that need to undergo eviction during drain.
+                      if specified. only pods that match PodEvictionFilters will be evicted during drain operation.
+                      if unspecified. all non-daemonset pods will be evicted.
+                      logical OR is performed between filter entires. logical AND is performed within different filters
+                      in a filter entry.
+                    items:
+                      description: PodEvictionFiterEntry defines filters for Pod evictions
+                        during drain operation
+                      properties:
+                        byResourceNameRegex:
+                          description: ByResourceNameRegex filters pods by the name
+                            of the resources they consume using regex.
+                          type: string
+                      type: object
+                    type: array
+                  podSelector:
+                    description: |-
+                      PodSelector specifies a label selector to filter pods on the node that need to be drained
+                      For more details on label selectors, see:
+                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                    type: string
+                  timeoutSeconds:
+                    default: 300
+                    description: TimeoutSecond specifies the length of time in seconds
+                      to wait before giving up drain, zero means infinite
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+              nodeName:
+                description: |-
+                  NodeName is The name of the node that maintenance operation will be performed on
+                  creation fails if node obj does not exist (webhook)
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              requestorID:
+                description: |-
+                  RequestorID MUST follow domain name notation format (https://tools.ietf.org/html/rfc1035#section-2.3.1)
+                  It MUST be 63 characters or less, beginning and ending with an alphanumeric
+                  character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between.
+                  caller SHOULD NOT create multiple objects with same requestorID and nodeName.
+                  This field identifies the requestor of the operation.
+                maxLength: 63
+                minLength: 2
+                pattern: ^([a-z0-9A-Z]([-a-z0-9A-Z]*[a-z0-9A-Z])?(\.[a-z0-9A-Z]([-a-z0-9A-Z]*[a-z0-9A-Z])?)*)$
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              waitForPodCompletion:
+                description: |-
+                  WaitForPodCompletion specifies pods via selector to wait for completion before performing drain operation
+                  if not provided, will not wait for pods to complete
+                properties:
+                  podSelector:
+                    description: |-
+                      PodSelector specifies a label selector for the pods to wait for completion
+                      For more details on label selectors, see:
+                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                    example: app=my-workloads
+                    type: string
+                  timeoutSeconds:
+                    default: 0
+                    description: |-
+                      TimeoutSecond specifies the length of time in seconds
+                      to wait before giving up on pod termination, zero means infinite
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+            required:
+            - nodeName
+            - requestorID
+            type: object
+          status:
+            description: NodeMaintenanceStatus defines the observed state of NodeMaintenance
+            properties:
+              conditions:
+                description: Conditions represents observations of NodeMaintenance
+                  current state
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              drain:
+                description: Drain represents the drain status of the node
+                properties:
+                  drainProgress:
+                    description: DrainProgress represents the draining progress as
+                      percentage
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  evictionPods:
+                    description: EvictionPods is the total number of pods that need
+                      to be evicted at the time NodeMaintenance started draining
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  totalPods:
+                    description: TotalPods is the number of pods on the node at the
+                      time NodeMaintenance started draining
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  waitForEviction:
+                    description: WaitForEviction is the list of namespaced named pods
+                      that need to be evicted
+                    items:
+                      type: string
+                    type: array
+                required:
+                - drainProgress
+                - evictionPods
+                - totalPods
+                type: object
+              waitForCompletion:
+                description: WaitForCompletion is the list of namespaced named pods
+                  that we wait to complete
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/upgrade/common_manager.go
+++ b/pkg/upgrade/common_manager.go
@@ -1,0 +1,778 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/NVIDIA/k8s-operator-libs/api/upgrade/v1alpha1"
+	"github.com/NVIDIA/k8s-operator-libs/pkg/consts"
+)
+
+// CommonUpgradeStateManager interface is a unified cluster upgrade abstraction for both upgrade modes
+type CommonUpgradeStateManager interface {
+	// GetTotalManagedNodes returns the total count of nodes managed for driver upgrades
+	GetTotalManagedNodes(currentState *ClusterUpgradeState) int
+	// GetUpgradesInProgress returns count of nodes on which upgrade is in progress
+	GetUpgradesInProgress(currentState *ClusterUpgradeState) int
+	// GetUpgradesDone returns count of nodes on which upgrade is complete
+	GetUpgradesDone(currentState *ClusterUpgradeState) int
+	// GetUpgradesAvailable returns count of nodes on which upgrade can be done
+	GetUpgradesAvailable(currentState *ClusterUpgradeState, maxParallelUpgrades int,
+		maxUnavailable int) int
+	// GetUpgradesFailed returns count of nodes on which upgrades have failed
+	GetUpgradesFailed(currentState *ClusterUpgradeState) int
+	// GetUpgradesPending returns count of nodes on which are marked for upgrades and upgrade is pending
+	GetUpgradesPending(currentState *ClusterUpgradeState) int
+	// IsPodDeletionEnabled returns true if 'pod-deletion' state is enabled
+	IsPodDeletionEnabled() bool
+	// IsValidationEnabled returns true if 'validation' state is enabled
+	IsValidationEnabled() bool
+}
+
+// ProcessNodeStateManager interface is used for abstracting both upgrade modes: in-place,
+// requestor (e.g. maintenance OP)
+// Similar node states are used in both modes, while changes are introduced within ApplyState Process<state>
+// methods to support both modes logic
+type ProcessNodeStateManager interface {
+	ProcessUpgradeRequiredNodes(ctx context.Context,
+		currentClusterState *ClusterUpgradeState, upgradePolicy *v1alpha1.DriverUpgradePolicySpec) error
+	ProcessNodeMaintenanceRequiredNodes(ctx context.Context,
+		currentClusterState *ClusterUpgradeState) error
+	ProcessUncordonRequiredNodes(
+		ctx context.Context, currentClusterState *ClusterUpgradeState) error
+}
+
+// NodeUpgradeState contains a mapping between a node,
+// the driver POD running on them and the daemon set, controlling this pod
+type NodeUpgradeState struct {
+	Node            *corev1.Node
+	DriverPod       *corev1.Pod
+	DriverDaemonSet *appsv1.DaemonSet
+	NodeMaintenance client.Object
+}
+
+// IsOrphanedPod returns true if Pod is not associated to a DaemonSet
+func (nus *NodeUpgradeState) IsOrphanedPod() bool {
+	return nus.DriverDaemonSet == nil
+}
+
+// ClusterUpgradeState contains a snapshot of the driver upgrade state in the cluster
+// Nodes are grouped together with the driver POD running on them and the daemon set, controlling this pod
+// This state is then used as an input for the ClusterUpgradeStateManager
+type ClusterUpgradeState struct {
+	NodeStates map[string][]*NodeUpgradeState
+}
+
+// NewClusterUpgradeState creates an empty ClusterUpgradeState object
+func NewClusterUpgradeState() ClusterUpgradeState {
+	return ClusterUpgradeState{NodeStates: make(map[string][]*NodeUpgradeState)}
+}
+
+// CommonUpgradeManagerImpl is an implementation of the CommonUpgradeStateManager interface.
+// It facilitates common logic implementation for both upgrade modes: in-place and requestor (e.g. maintenance OP).
+type CommonUpgradeManagerImpl struct {
+	Log           logr.Logger
+	K8sClient     client.Client
+	K8sInterface  kubernetes.Interface
+	EventRecorder record.EventRecorder
+
+	DrainManager             DrainManager
+	PodManager               PodManager
+	CordonManager            CordonManager
+	NodeUpgradeStateProvider NodeUpgradeStateProvider
+	ValidationManager        ValidationManager
+	SafeDriverLoadManager    SafeDriverLoadManager
+
+	// optional states
+	podDeletionStateEnabled bool
+	validationStateEnabled  bool
+}
+
+// NewCommonUpgradeStateManager creates a new instance of CommonUpgradeManagerImpl
+func NewCommonUpgradeStateManager(
+	log logr.Logger,
+	k8sConfig *rest.Config,
+	scheme *runtime.Scheme,
+	eventRecorder record.EventRecorder) (*CommonUpgradeManagerImpl, error) {
+	k8sClient, err := client.New(k8sConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return &CommonUpgradeManagerImpl{}, fmt.Errorf("error creating k8s client: %v", err)
+	}
+
+	k8sInterface, err := kubernetes.NewForConfig(k8sConfig)
+	if err != nil {
+		return &CommonUpgradeManagerImpl{}, fmt.Errorf("error creating k8s interface: %v", err)
+	}
+
+	nodeUpgradeStateProvider := NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
+	commonUpgrade := CommonUpgradeManagerImpl{
+		Log:                      log,
+		K8sClient:                k8sClient,
+		K8sInterface:             k8sInterface,
+		EventRecorder:            eventRecorder,
+		DrainManager:             NewDrainManager(k8sInterface, nodeUpgradeStateProvider, log, eventRecorder),
+		PodManager:               NewPodManager(k8sInterface, nodeUpgradeStateProvider, log, nil, eventRecorder),
+		CordonManager:            NewCordonManager(k8sInterface, log),
+		NodeUpgradeStateProvider: nodeUpgradeStateProvider,
+		ValidationManager:        NewValidationManager(k8sInterface, log, eventRecorder, nodeUpgradeStateProvider, ""),
+		SafeDriverLoadManager:    NewSafeDriverLoadManager(nodeUpgradeStateProvider, log),
+	}
+
+	return &commonUpgrade, nil
+}
+
+// IsPodDeletionEnabled returns true if 'pod-deletion' state is enabled
+func (m *CommonUpgradeManagerImpl) IsPodDeletionEnabled() bool {
+	return m.podDeletionStateEnabled
+}
+
+// IsValidationEnabled returns true if 'validation' state is enabled
+func (m *CommonUpgradeManagerImpl) IsValidationEnabled() bool {
+	return m.validationStateEnabled
+}
+
+// GetCurrentUnavailableNodes returns all nodes that are not in ready state
+func (m *CommonUpgradeManagerImpl) GetCurrentUnavailableNodes(
+	currentState *ClusterUpgradeState) int {
+	unavailableNodes := 0
+	for _, nodeUpgradeStateList := range currentState.NodeStates {
+		for _, nodeUpgradeState := range nodeUpgradeStateList {
+			// check if the node is cordoned
+			if m.IsNodeUnschedulable(nodeUpgradeState.Node) {
+				m.Log.V(consts.LogLevelDebug).Info("Node is cordoned", "node", nodeUpgradeState.Node.Name)
+				unavailableNodes++
+				continue
+			}
+			// check if the node is not ready
+			if !m.isNodeConditionReady(nodeUpgradeState.Node) {
+				m.Log.V(consts.LogLevelDebug).Info("Node is not-ready", "node", nodeUpgradeState.Node.Name)
+				unavailableNodes++
+			}
+		}
+	}
+	return unavailableNodes
+}
+
+// GetDriverDaemonSets retrieves DaemonSets with given labels and returns UID->DaemonSet map
+func (m *CommonUpgradeManagerImpl) GetDriverDaemonSets(ctx context.Context, namespace string,
+	labels map[string]string) (map[types.UID]*appsv1.DaemonSet, error) {
+	// Get list of driver pods
+	daemonSetList := &appsv1.DaemonSetList{}
+
+	err := m.K8sClient.List(ctx, daemonSetList,
+		client.InNamespace(namespace),
+		client.MatchingLabels(labels))
+	if err != nil {
+		return nil, fmt.Errorf("error getting DaemonSet list: %v", err)
+	}
+
+	daemonSetMap := make(map[types.UID]*appsv1.DaemonSet)
+	for i := range daemonSetList.Items {
+		daemonSet := &daemonSetList.Items[i]
+		daemonSetMap[daemonSet.UID] = daemonSet
+	}
+
+	return daemonSetMap, nil
+}
+
+// GetPodsOwnedbyDs returns a list of the pods owned by the specified DaemonSet
+func (m *CommonUpgradeManagerImpl) GetPodsOwnedbyDs(ds *appsv1.DaemonSet, pods []corev1.Pod) []corev1.Pod {
+	dsPodList := []corev1.Pod{}
+	for i := range pods {
+		pod := &pods[i]
+		if IsOrphanedPod(pod) {
+			m.Log.V(consts.LogLevelInfo).Info("Driver Pod has no owner DaemonSet", "pod", pod.Name)
+			continue
+		}
+		m.Log.V(consts.LogLevelInfo).Info("Pod", "pod", pod.Name, "owner", pod.OwnerReferences[0].Name)
+
+		if ds.UID != pod.OwnerReferences[0].UID {
+			m.Log.V(consts.LogLevelInfo).Info("Driver Pod is not owned by an Driver DaemonSet",
+				"pod", pod, "actual owner", pod.OwnerReferences[0])
+			continue
+		}
+		dsPodList = append(dsPodList, *pod)
+	}
+	return dsPodList
+}
+
+// GetOrphanedPods returns a list of the pods not owned by any DaemonSet
+func (m *CommonUpgradeManagerImpl) GetOrphanedPods(pods []corev1.Pod) []corev1.Pod {
+	podList := []corev1.Pod{}
+	for i := range pods {
+		pod := &pods[i]
+		if IsOrphanedPod(pod) {
+			podList = append(podList, *pod)
+		}
+	}
+	m.Log.V(consts.LogLevelInfo).Info("Total orphaned Pods found:", "count", len(podList))
+	return podList
+}
+
+func IsOrphanedPod(pod *corev1.Pod) bool {
+	return pod.OwnerReferences == nil || len(pod.OwnerReferences) < 1
+}
+
+// ProcessDoneOrUnknownNodes iterates over UpgradeStateDone or UpgradeStateUnknown nodes and determines
+// whether each specific node should be in UpgradeStateUpgradeRequired or UpgradeStateDone state.
+func (m *CommonUpgradeManagerImpl) ProcessDoneOrUnknownNodes(
+	ctx context.Context, currentClusterState *ClusterUpgradeState, nodeStateName string) error {
+	m.Log.V(consts.LogLevelInfo).Info("ProcessDoneOrUnknownNodes")
+
+	for _, nodeState := range currentClusterState.NodeStates[nodeStateName] {
+		isPodSynced, isOrphaned, err := m.podInSyncWithDS(ctx, nodeState)
+		if err != nil {
+			m.Log.V(consts.LogLevelError).Error(err, "Failed to get daemonset template/pod revision hash")
+			return err
+		}
+		isUpgradeRequested := m.IsUpgradeRequested(nodeState.Node)
+		isWaitingForSafeDriverLoad, err := m.SafeDriverLoadManager.IsWaitingForSafeDriverLoad(ctx, nodeState.Node)
+		if err != nil {
+			m.Log.V(consts.LogLevelError).Error(
+				err, "Failed to check safe driver load status for the node", "node", nodeState.Node.Name)
+			return err
+		}
+		if isWaitingForSafeDriverLoad {
+			m.Log.V(consts.LogLevelInfo).Info("Node is waiting for safe driver load, initialize upgrade",
+				"node", nodeState.Node.Name)
+		}
+		if (!isPodSynced && !isOrphaned) || isWaitingForSafeDriverLoad || isUpgradeRequested {
+			// If node requires upgrade and is Unschedulable, track this in an
+			// annotation and leave node in Unschedulable state when upgrade completes.
+			if IsNodeUnschedulable(nodeState.Node) {
+				annotationKey := GetUpgradeInitialStateAnnotationKey()
+				annotationValue := trueString
+				m.Log.V(consts.LogLevelInfo).Info(
+					"Node is unschedulable, adding annotation to track initial state of the node",
+					"node", nodeState.Node.Name, "annotation", annotationKey)
+				err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeAnnotation(ctx, nodeState.Node, annotationKey,
+					annotationValue)
+				if err != nil {
+					return err
+				}
+			}
+			err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateUpgradeRequired)
+			if err != nil {
+				m.Log.V(consts.LogLevelError).Error(
+					err, "Failed to change node upgrade state", "state", UpgradeStateUpgradeRequired, "node:", nodeState.Node)
+				return err
+			}
+			m.Log.V(consts.LogLevelInfo).Info("Node requires upgrade, changed its state to UpgradeRequired",
+				"node", nodeState.Node.Name)
+			continue
+		}
+
+		if nodeStateName == UpgradeStateUnknown {
+			err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateDone)
+			if err != nil {
+				m.Log.V(consts.LogLevelError).Error(
+					err, "Failed to change node upgrade state", "state", UpgradeStateDone)
+				return err
+			}
+			m.Log.V(consts.LogLevelInfo).Info("Changed node state to UpgradeDone",
+				"node", nodeState.Node.Name)
+			continue
+		}
+		m.Log.V(consts.LogLevelDebug).Info("Node in UpgradeDone state, upgrade not required",
+			"node", nodeState.Node.Name)
+	}
+	return nil
+}
+
+// podInSyncWithDS check if pod is in sync with DaemonSet, handling also Orphaned Pod
+// Returns:
+//
+//	bool: True if Pod is in sync with DaemonSet. (For Orphanded Pods, always false)
+//	bool: True if the Pod is Orphaned
+//	error: In case of error retrivieng the Revision Hashes
+func (m *CommonUpgradeManagerImpl) podInSyncWithDS(ctx context.Context,
+	nodeState *NodeUpgradeState) (isPodSynced, isOrphened bool, err error) {
+	if isOrphened = nodeState.IsOrphanedPod(); isOrphened {
+		return isPodSynced, isOrphened, nil
+	}
+	podRevisionHash, err := m.PodManager.GetPodControllerRevisionHash(nodeState.DriverPod)
+	if err != nil {
+		m.Log.V(consts.LogLevelError).Error(
+			err, "Failed to get pod template revision hash", "pod", nodeState.DriverPod)
+		return isPodSynced, isOrphened, err
+	}
+	m.Log.V(consts.LogLevelDebug).Info("pod template revision hash", "hash", podRevisionHash)
+	daemonsetRevisionHash, err := m.PodManager.GetDaemonsetControllerRevisionHash(ctx, nodeState.DriverDaemonSet)
+	if err != nil {
+		m.Log.V(consts.LogLevelError).Error(
+			err, "Failed to get daemonset template revision hash", "daemonset", nodeState.DriverDaemonSet)
+		return isPodSynced, isOrphened, err
+	}
+	m.Log.V(consts.LogLevelDebug).Info("daemonset template revision hash", "hash", daemonsetRevisionHash)
+	isPodSynced = podRevisionHash == daemonsetRevisionHash
+	return isPodSynced, isOrphened, nil
+}
+
+// isUpgradeRequested returns true if node is labeled to request an upgrade
+func (m *CommonUpgradeManagerImpl) IsUpgradeRequested(node *corev1.Node) bool {
+	return node.Annotations[GetUpgradeRequestedAnnotationKey()] == trueString
+}
+
+// ProcessDrainNodes schedules UpgradeStateDrainRequired nodes for drain.
+// If drain is disabled by upgrade policy, moves the nodes straight to UpgradeStatePodRestartRequired state.
+func (m *CommonUpgradeManagerImpl) ProcessDrainNodes(
+	ctx context.Context, currentClusterState *ClusterUpgradeState, drainSpec *v1alpha1.DrainSpec) error {
+	m.Log.V(consts.LogLevelInfo).Info("ProcessDrainNodes")
+	if drainSpec == nil || !drainSpec.Enable {
+		// If node drain is disabled, move nodes straight to PodRestart stage
+		m.Log.V(consts.LogLevelInfo).Info("Node drain is disabled by policy, skipping this step")
+		for _, nodeState := range currentClusterState.NodeStates[UpgradeStateDrainRequired] {
+			err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStatePodRestartRequired)
+			if err != nil {
+				m.Log.V(consts.LogLevelError).Error(
+					err, "Failed to change node upgrade state", "state", UpgradeStatePodRestartRequired)
+				return err
+			}
+		}
+		return nil
+	}
+
+	drainConfig := DrainConfiguration{
+		Spec:  drainSpec,
+		Nodes: make([]*corev1.Node, 0, len(currentClusterState.NodeStates[UpgradeStateDrainRequired])),
+	}
+	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateDrainRequired] {
+		drainConfig.Nodes = append(drainConfig.Nodes, nodeState.Node)
+	}
+
+	m.Log.V(consts.LogLevelInfo).Info("Scheduling nodes drain", "drainConfig", drainConfig)
+
+	return m.DrainManager.ScheduleNodesDrain(ctx, &drainConfig)
+}
+
+// ProcessCordonRequiredNodes processes UpgradeStateCordonRequired nodes,
+// cordons them and moves them to UpgradeStateWaitForJobsRequired state
+func (m *CommonUpgradeManagerImpl) ProcessCordonRequiredNodes(
+	ctx context.Context, currentClusterState *ClusterUpgradeState) error {
+	m.Log.V(consts.LogLevelInfo).Info("ProcessCordonRequiredNodes")
+
+	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateCordonRequired] {
+		err := m.CordonManager.Cordon(ctx, nodeState.Node)
+		if err != nil {
+			m.Log.V(consts.LogLevelWarning).Error(
+				err, "Node cordon failed", "node", nodeState.Node)
+			return err
+		}
+		err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateWaitForJobsRequired)
+		if err != nil {
+			m.Log.V(consts.LogLevelError).Error(
+				err, "Failed to change node upgrade state", "state", UpgradeStateWaitForJobsRequired)
+			return err
+		}
+	}
+	return nil
+}
+
+// ProcessWaitForJobsRequiredNodes processes UpgradeStateWaitForJobsRequired nodes,
+// waits for completion of jobs and moves them to UpgradeStatePodDeletionRequired state.
+func (m *CommonUpgradeManagerImpl) ProcessWaitForJobsRequiredNodes(
+	ctx context.Context, currentClusterState *ClusterUpgradeState,
+	waitForCompletionSpec *v1alpha1.WaitForCompletionSpec) error {
+	m.Log.V(consts.LogLevelInfo).Info("ProcessWaitForJobsRequiredNodes")
+
+	nodes := make([]*corev1.Node, 0, len(currentClusterState.NodeStates[UpgradeStateWaitForJobsRequired]))
+	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateWaitForJobsRequired] {
+		nodes = append(nodes, nodeState.Node)
+		if waitForCompletionSpec == nil || waitForCompletionSpec.PodSelector == "" {
+			// update node state to next state as no pod selector is specified for waiting
+			m.Log.V(consts.LogLevelInfo).Info("No jobs to wait for as no pod selector was provided. Moving to next state.")
+			nextState := UpgradeStatePodDeletionRequired
+			if !m.IsPodDeletionEnabled() {
+				nextState = UpgradeStateDrainRequired
+			}
+			_ = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, nextState)
+			m.Log.V(consts.LogLevelInfo).Info("Updated the node state", "node", nodeState.Node.Name, "state", nextState)
+		}
+	}
+	// return if no pod selector is provided for waiting
+	if waitForCompletionSpec == nil || waitForCompletionSpec.PodSelector == "" {
+		return nil
+	}
+
+	if len(nodes) == 0 {
+		// no nodes to process in this state
+		return nil
+	}
+
+	podManagerConfig := PodManagerConfig{WaitForCompletionSpec: waitForCompletionSpec, Nodes: nodes}
+	err := m.PodManager.ScheduleCheckOnPodCompletion(ctx, &podManagerConfig)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ProcessPodDeletionRequiredNodes processes UpgradeStatePodDeletionRequired nodes,
+// deletes select pods on a node, and moves the nodes to UpgradeStateDrainRequiredRequired state.
+// Pods selected for deletion are determined via PodManager.PodDeletion
+func (m *CommonUpgradeManagerImpl) ProcessPodDeletionRequiredNodes(
+	ctx context.Context, currentClusterState *ClusterUpgradeState, podDeletionSpec *v1alpha1.PodDeletionSpec,
+	drainEnabled bool) error {
+	m.Log.V(consts.LogLevelInfo).Info("ProcessPodDeletionRequiredNodes")
+
+	if !m.IsPodDeletionEnabled() {
+		m.Log.V(consts.LogLevelInfo).Info("PodDeletion is not enabled, proceeding straight to the next state")
+		for _, nodeState := range currentClusterState.NodeStates[UpgradeStatePodDeletionRequired] {
+			_ = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateDrainRequired)
+		}
+		return nil
+	}
+
+	podManagerConfig := PodManagerConfig{
+		DeletionSpec: podDeletionSpec,
+		DrainEnabled: drainEnabled,
+		Nodes:        make([]*corev1.Node, 0, len(currentClusterState.NodeStates[UpgradeStatePodDeletionRequired])),
+	}
+
+	for _, nodeState := range currentClusterState.NodeStates[UpgradeStatePodDeletionRequired] {
+		podManagerConfig.Nodes = append(podManagerConfig.Nodes, nodeState.Node)
+	}
+
+	if len(podManagerConfig.Nodes) == 0 {
+		// no nodes to process in this state
+		return nil
+	}
+
+	return m.PodManager.SchedulePodEviction(ctx, &podManagerConfig)
+}
+
+// ProcessPodRestartNodes processes UpgradeStatePodRestartRequired nodes and schedules driver pod restart for them.
+// If the pod has already been restarted and is in Ready state - moves the node to UpgradeStateUncordonRequired state.
+func (m *CommonUpgradeManagerImpl) ProcessPodRestartNodes(
+	ctx context.Context, currentClusterState *ClusterUpgradeState) error {
+	m.Log.V(consts.LogLevelInfo).Info("ProcessPodRestartNodes")
+
+	pods := make([]*corev1.Pod, 0, len(currentClusterState.NodeStates[UpgradeStatePodRestartRequired]))
+	for _, nodeState := range currentClusterState.NodeStates[UpgradeStatePodRestartRequired] {
+		isPodSynced, isOrphaned, err := m.podInSyncWithDS(ctx, nodeState)
+		if err != nil {
+			m.Log.V(consts.LogLevelError).Error(err, "Failed to get daemonset template/pod revision hash")
+			return err
+		}
+		if !isPodSynced || isOrphaned {
+			// Pods should only be scheduled for restart if they are not terminating or restarting already
+			// To determinate terminating state we need to check for deletion timestamp which will be set
+			// once pod termination process started
+			if nodeState.DriverPod.ObjectMeta.DeletionTimestamp.IsZero() {
+				pods = append(pods, nodeState.DriverPod)
+			}
+		} else {
+			err := m.SafeDriverLoadManager.UnblockLoading(ctx, nodeState.Node)
+			if err != nil {
+				m.Log.V(consts.LogLevelError).Error(
+					err, "Failed to unblock loading of the driver", "nodeState", nodeState)
+				return err
+			}
+			driverPodInSync, err := m.isDriverPodInSync(ctx, nodeState)
+			if err != nil {
+				m.Log.V(consts.LogLevelError).Error(
+					err, "Failed to check if driver pod on the node is in sync", "nodeState", nodeState)
+				return err
+			}
+			if driverPodInSync {
+				if !m.IsValidationEnabled() {
+					err = m.updateNodeToUncordonOrDoneState(ctx, nodeState.Node)
+					if err != nil {
+						return err
+					}
+					continue
+				}
+
+				err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node,
+					UpgradeStateValidationRequired)
+				if err != nil {
+					m.Log.V(consts.LogLevelError).Error(
+						err, "Failed to change node upgrade state", "state", UpgradeStateValidationRequired)
+					return err
+				}
+			} else {
+				// driver pod not in sync, move node to failed state if repeated container restarts
+				if !m.isDriverPodFailing(nodeState.DriverPod) {
+					continue
+				}
+				m.Log.V(consts.LogLevelInfo).Info("Driver pod is failing on node with repeated restarts",
+					"node", nodeState.Node.Name, "pod", nodeState.DriverPod.Name)
+				err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateFailed)
+				if err != nil {
+					m.Log.V(consts.LogLevelError).Error(
+						err, "Failed to change node upgrade state for node", "node", nodeState.Node.Name,
+						"state", UpgradeStateFailed)
+					return err
+				}
+			}
+		}
+	}
+
+	// Create pod restart manager to handle pod restarts
+	return m.PodManager.SchedulePodsRestart(ctx, pods)
+}
+
+// ProcessUpgradeFailedNodes processes UpgradeStateFailed nodes and checks whether the driver pod on the node
+// has been successfully restarted. If the pod is in Ready state - moves the node to UpgradeStateUncordonRequired state.
+func (m *CommonUpgradeManagerImpl) ProcessUpgradeFailedNodes(
+	ctx context.Context, currentClusterState *ClusterUpgradeState) error {
+	m.Log.V(consts.LogLevelInfo).Info("ProcessUpgradeFailedNodes")
+
+	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateFailed] {
+		driverPodInSync, err := m.isDriverPodInSync(ctx, nodeState)
+		if err != nil {
+			m.Log.V(consts.LogLevelError).Error(
+				err, "Failed to check if driver pod on the node is in sync", "nodeState", nodeState)
+			return err
+		}
+		if driverPodInSync {
+			newUpgradeState := UpgradeStateUncordonRequired
+			// If node was Unschedulable at beginning of upgrade, skip the
+			// uncordon state so that node remains in the same state as
+			// when the upgrade started.
+			annotationKey := GetUpgradeInitialStateAnnotationKey()
+			if _, ok := nodeState.Node.Annotations[annotationKey]; ok {
+				m.Log.V(consts.LogLevelInfo).Info("Node was Unschedulable at beginning of upgrade, skipping uncordon",
+					"node", nodeState.Node.Name)
+				newUpgradeState = UpgradeStateDone
+			}
+
+			err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, newUpgradeState)
+			if err != nil {
+				m.Log.V(consts.LogLevelError).Error(
+					err, "Failed to change node upgrade state", "state", newUpgradeState)
+				return err
+			}
+
+			if newUpgradeState == UpgradeStateDone {
+				m.Log.V(consts.LogLevelDebug).Info("Removing node upgrade annotation",
+					"node", nodeState.Node.Name, "annotation", annotationKey)
+				err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeAnnotation(ctx, nodeState.Node, annotationKey, "null")
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// ProcessValidationRequiredNodes processes UpgradeStateValidationRequired nodes
+func (m *CommonUpgradeManagerImpl) ProcessValidationRequiredNodes(
+	ctx context.Context, currentClusterState *ClusterUpgradeState) error {
+	m.Log.V(consts.LogLevelInfo).Info("ProcessValidationRequiredNodes")
+
+	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateValidationRequired] {
+		node := nodeState.Node
+		// make sure that the driver Pod is not waiting for the safe load,
+		// this may happen in case if driver restarted after it was moved to UpgradeStateValidationRequired state
+		err := m.SafeDriverLoadManager.UnblockLoading(ctx, nodeState.Node)
+		if err != nil {
+			m.Log.V(consts.LogLevelError).Error(
+				err, "Failed to unblock loading of the driver", "nodeState", nodeState)
+			return err
+		}
+		validationDone, err := m.ValidationManager.Validate(ctx, node)
+		if err != nil {
+			m.Log.V(consts.LogLevelError).Error(err, "Failed to validate driver upgrade", "node", node.Name)
+			return err
+		}
+
+		if !validationDone {
+			m.Log.V(consts.LogLevelInfo).Info("Validations not complete on the node", "node", node.Name)
+			continue
+		}
+
+		err = m.updateNodeToUncordonOrDoneState(ctx, node)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *CommonUpgradeManagerImpl) isDriverPodInSync(ctx context.Context,
+	nodeState *NodeUpgradeState) (bool, error) {
+	isPodSynced, isOrphaned, err := m.podInSyncWithDS(ctx, nodeState)
+	if err != nil {
+		m.Log.V(consts.LogLevelError).Error(err, "Failed to get daemonset template/pod revision hash")
+		return false, err
+	}
+	if isOrphaned {
+		return false, nil
+	}
+	// If the pod generation matches the daemonset generation
+	if isPodSynced &&
+		// And the pod is running
+		nodeState.DriverPod.Status.Phase == corev1.PodRunning &&
+		// And it has at least 1 container
+		len(nodeState.DriverPod.Status.ContainerStatuses) != 0 {
+		for i := range nodeState.DriverPod.Status.ContainerStatuses {
+			if !nodeState.DriverPod.Status.ContainerStatuses[i].Ready {
+				// Return false if at least 1 container isn't ready
+				return false, nil
+			}
+		}
+
+		// And each container is ready
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (m *CommonUpgradeManagerImpl) isDriverPodFailing(pod *corev1.Pod) bool {
+	for _, status := range pod.Status.InitContainerStatuses {
+		if !status.Ready && status.RestartCount > 10 {
+			return true
+		}
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if !status.Ready && status.RestartCount > 10 {
+			return true
+		}
+	}
+	return false
+}
+
+// isNodeUnschedulable returns true if the node is cordoned
+func (m *CommonUpgradeManagerImpl) IsNodeUnschedulable(node *corev1.Node) bool {
+	return node.Spec.Unschedulable
+}
+
+// isNodeConditionReady returns true if the node condition is ready
+func (m *CommonUpgradeManagerImpl) isNodeConditionReady(node *corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady && condition.Status != corev1.ConditionTrue {
+			return false
+		}
+	}
+	return true
+}
+
+// skipNodeUpgrade returns true if node is labeled to skip driver upgrades
+func (m *CommonUpgradeManagerImpl) SkipNodeUpgrade(node *corev1.Node) bool {
+	return node.Labels[GetUpgradeSkipNodeLabelKey()] == trueString
+}
+
+// updateNodeToUncordonOrDoneState skips moving the node to the UncordonRequired state if the node
+// was Unschedulable at the beginning of the upgrade so that the node remains in the same state as
+// when the upgrade started. In addition, the annotation tracking this information is removed.
+func (m *CommonUpgradeManagerImpl) updateNodeToUncordonOrDoneState(ctx context.Context, node *corev1.Node) error {
+	newUpgradeState := UpgradeStateUncordonRequired
+	annotationKey := GetUpgradeInitialStateAnnotationKey()
+	if _, ok := node.Annotations[annotationKey]; ok {
+		m.Log.V(consts.LogLevelInfo).Info("Node was Unschedulable at beginning of upgrade, skipping uncordon",
+			"node", node.Name)
+		newUpgradeState = UpgradeStateDone
+	}
+
+	err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, node, newUpgradeState)
+	if err != nil {
+		m.Log.V(consts.LogLevelError).Error(
+			err, "Failed to change node upgrade state", "node", node.Name, "state", newUpgradeState)
+		return err
+	}
+
+	if newUpgradeState == UpgradeStateDone {
+		m.Log.V(consts.LogLevelDebug).Info("Removing node upgrade annotation",
+			"node", node.Name, "annotation", annotationKey)
+		err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeAnnotation(ctx, node, annotationKey, "null")
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func IsNodeUnschedulable(node *corev1.Node) bool {
+	return node.Spec.Unschedulable
+}
+
+// GetTotalManagedNodes returns the total count of nodes managed for driver upgrades
+func (m *CommonUpgradeManagerImpl) GetTotalManagedNodes(
+	currentState *ClusterUpgradeState) int {
+	totalNodes := len(currentState.NodeStates[UpgradeStateUnknown]) +
+		len(currentState.NodeStates[UpgradeStateDone]) +
+		len(currentState.NodeStates[UpgradeStateUpgradeRequired]) +
+		len(currentState.NodeStates[UpgradeStateCordonRequired]) +
+		len(currentState.NodeStates[UpgradeStateWaitForJobsRequired]) +
+		len(currentState.NodeStates[UpgradeStatePodDeletionRequired]) +
+		len(currentState.NodeStates[UpgradeStateFailed]) +
+		len(currentState.NodeStates[UpgradeStateDrainRequired]) +
+		len(currentState.NodeStates[UpgradeStatePodRestartRequired]) +
+		len(currentState.NodeStates[UpgradeStateUncordonRequired]) +
+		len(currentState.NodeStates[UpgradeStateValidationRequired])
+
+	return totalNodes
+}
+
+// GetUpgradesInProgress returns count of nodes on which upgrade is in progress
+func (m *CommonUpgradeManagerImpl) GetUpgradesInProgress(
+	currentState *ClusterUpgradeState) int {
+	totalNodes := m.GetTotalManagedNodes(currentState)
+	return totalNodes - (len(currentState.NodeStates[UpgradeStateUnknown]) +
+		len(currentState.NodeStates[UpgradeStateDone]) +
+		len(currentState.NodeStates[UpgradeStateUpgradeRequired]))
+}
+
+// GetUpgradesDone returns count of nodes on which upgrade is complete
+func (m *CommonUpgradeManagerImpl) GetUpgradesDone(
+	currentState *ClusterUpgradeState) int {
+	return len(currentState.NodeStates[UpgradeStateDone])
+}
+
+// GetUpgradesAvailable returns count of nodes on which upgrade can be done
+func (m *CommonUpgradeManagerImpl) GetUpgradesAvailable(
+	currentState *ClusterUpgradeState, maxParallelUpgrades int, maxUnavailable int) int {
+	upgradesInProgress := m.GetUpgradesInProgress(currentState)
+	totalNodes := m.GetTotalManagedNodes(currentState)
+
+	var upgradesAvailable int
+	if maxParallelUpgrades == 0 {
+		// Only nodes in UpgradeStateUpgradeRequired can start upgrading, so all of them will move to drain stage
+		upgradesAvailable = len(currentState.NodeStates[UpgradeStateUpgradeRequired])
+	} else {
+		upgradesAvailable = maxParallelUpgrades - upgradesInProgress
+	}
+
+	// Apply the maxUnavailable constraint based on the number of nodes unavailable in the cluster
+	// Get nodes in cordoned/not-ready state and also include nodes that are about to be cordoned.
+	currentUnavailableNodes := m.GetCurrentUnavailableNodes(currentState) +
+		len(currentState.NodeStates[UpgradeStateCordonRequired])
+	// always limit upgradesAvailalbe to maxUnavailable
+	if upgradesAvailable > maxUnavailable {
+		upgradesAvailable = maxUnavailable
+	}
+	// apply additional limits when there are already unavailable nodes
+	if currentUnavailableNodes >= maxUnavailable {
+		upgradesAvailable = 0
+	} else if maxUnavailable < totalNodes && currentUnavailableNodes+upgradesAvailable > maxUnavailable {
+		upgradesAvailable = maxUnavailable - currentUnavailableNodes
+	}
+	return upgradesAvailable
+}
+
+// GetUpgradesFailed returns count of nodes on which upgrades have failed
+func (m *CommonUpgradeManagerImpl) GetUpgradesFailed(
+	currentState *ClusterUpgradeState) int {
+	return len(currentState.NodeStates[UpgradeStateFailed])
+}
+
+// GetUpgradesPending returns count of nodes on which are marked for upgrades and upgrade is pending
+func (m *CommonUpgradeManagerImpl) GetUpgradesPending(
+	currentState *ClusterUpgradeState) int {
+	return len(currentState.NodeStates[UpgradeStateUpgradeRequired])
+}

--- a/pkg/upgrade/consts.go
+++ b/pkg/upgrade/consts.go
@@ -39,6 +39,8 @@ const (
 	// (used for orphaned pods)
 	// Setting this label will trigger setting upgrade state to upgrade-required
 	UpgradeRequestedAnnotationKeyFmt = "nvidia.com/%s-driver-upgrade-requested"
+	// UpgradeRequestorModeAnnotationKeyFmt
+	UpgradeRequestorModeAnnotationKeyFmt = "nvidia.com/%s-driver-upgrade-requestor-mode"
 	// UpgradeStateUnknown Node has this state when the upgrade flow is disabled or the node hasn't been processed yet
 	UpgradeStateUnknown = ""
 	// UpgradeStateUpgradeRequired is set when the driver pod on the node is not up-to-date and required upgrade
@@ -53,6 +55,15 @@ const (
 	// UpgradeStateDrainRequired is set when the node is required to be scheduled for drain. After the drain the state
 	// is changed either to UpgradeStatePodRestartRequired or UpgradeStateFailed
 	UpgradeStateDrainRequired = "drain-required"
+	// UpgradeStateNodeMaintenanceRequired is set when the node is scheduled for node maintenance.
+	// The node maintenance operations, like cordon, drain, etc., are carried out by an external maintenance
+	// operator. This state is only ever used / valid when UseMaintenanceOperator is true and
+	// an external maintenance operator exists.
+	UpgradeStateNodeMaintenanceRequired = "node-maintenance-required"
+	// UpgradeStatePostMaintenanceRequired is set after node maintenance is completed by an
+	// external maintenance operator. This state indicates that the requestor is required to perform
+	// post-maintenance operations (e.g. restart driver pods).
+	UpgradeStatePostMaintenanceRequired = "post-maintenance-required"
 	// UpgradeStatePodRestartRequired is set when the driver pod on the node is scheduled for restart
 	// or when unblock of the driver loading is required (safe driver load)
 	UpgradeStatePodRestartRequired = "pod-restart-required"

--- a/pkg/upgrade/cordon_manager_test.go
+++ b/pkg/upgrade/cordon_manager_test.go
@@ -17,25 +17,22 @@ limitations under the License.
 package upgrade_test
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/NVIDIA/k8s-operator-libs/pkg/upgrade"
+	upgrade "github.com/NVIDIA/k8s-operator-libs/pkg/upgrade"
 )
 
 var _ = Describe("CordonManager tests", func() {
 	It("CordonManager should mark a node as schedulable/unschedulable", func() {
-		ctx := context.TODO()
 		node := createNode("test-node")
 
 		cordonManager := upgrade.NewCordonManager(k8sInterface, log)
-		err := cordonManager.Cordon(ctx, node)
+		err := cordonManager.Cordon(testCtx, node)
 		Expect(err).To(Succeed())
 		Expect(node.Spec.Unschedulable).To(BeTrue())
 
-		err = cordonManager.Uncordon(ctx, node)
+		err = cordonManager.Uncordon(testCtx, node)
 		Expect(err).To(Succeed())
 		Expect(node.Spec.Unschedulable).To(BeFalse())
 	})

--- a/pkg/upgrade/drain_manager_test.go
+++ b/pkg/upgrade/drain_manager_test.go
@@ -31,8 +31,6 @@ import (
 
 var _ = Describe("DrainManager tests", func() {
 	It("DrainManager should drain nodes", func() {
-		ctx := context.TODO()
-
 		node := createNode("node")
 
 		drainManager := upgrade.NewDrainManager(k8sInterface, upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder), log, eventRecorder)
@@ -44,18 +42,18 @@ var _ = Describe("DrainManager tests", func() {
 			DeleteEmptyDir: true,
 		}
 		nodeArray := []*corev1.Node{node}
-		err := drainManager.ScheduleNodesDrain(ctx, &upgrade.DrainConfiguration{Nodes: nodeArray, Spec: drainSpec})
+		err := drainManager.ScheduleNodesDrain(testCtx, &upgrade.DrainConfiguration{Nodes: nodeArray, Spec: drainSpec})
 		Expect(err).To(Succeed())
 
 		time.Sleep(time.Second)
 
 		observedNode := &corev1.Node{}
-		err = k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, observedNode)
+		err = k8sClient.Get(testCtx, types.NamespacedName{Name: node.Name}, observedNode)
 		Expect(err).To(Succeed())
 		Expect(observedNode.Spec.Unschedulable).To(BeTrue())
 	})
 	It("DrainManager should drain all nodes it receives", func() {
-		ctx := context.TODO()
+		testCtx := context.TODO()
 
 		node1 := createNode("node1")
 		node2 := createNode("node2")
@@ -70,28 +68,28 @@ var _ = Describe("DrainManager tests", func() {
 			DeleteEmptyDir: true,
 		}
 		nodeArray := []*corev1.Node{node1, node2, node3}
-		err := drainManager.ScheduleNodesDrain(ctx, &upgrade.DrainConfiguration{Nodes: nodeArray, Spec: drainSpec})
+		err := drainManager.ScheduleNodesDrain(testCtx, &upgrade.DrainConfiguration{Nodes: nodeArray, Spec: drainSpec})
 		Expect(err).To(Succeed())
 
 		time.Sleep(time.Second)
 
 		observedNode1 := &corev1.Node{}
-		err = k8sClient.Get(ctx, types.NamespacedName{Name: node1.Name}, observedNode1)
+		err = k8sClient.Get(testCtx, types.NamespacedName{Name: node1.Name}, observedNode1)
 		Expect(err).To(Succeed())
 		Expect(observedNode1.Spec.Unschedulable).To(BeTrue())
 
 		observedNode2 := &corev1.Node{}
-		err = k8sClient.Get(ctx, types.NamespacedName{Name: node2.Name}, observedNode2)
+		err = k8sClient.Get(testCtx, types.NamespacedName{Name: node2.Name}, observedNode2)
 		Expect(err).To(Succeed())
 		Expect(observedNode2.Spec.Unschedulable).To(BeTrue())
 
 		observedNode3 := &corev1.Node{}
-		err = k8sClient.Get(ctx, types.NamespacedName{Name: node3.Name}, observedNode3)
+		err = k8sClient.Get(testCtx, types.NamespacedName{Name: node3.Name}, observedNode3)
 		Expect(err).To(Succeed())
 		Expect(observedNode3.Spec.Unschedulable).To(BeTrue())
 	})
 	It("DrainManager should not fail on empty node list", func() {
-		ctx := context.TODO()
+		testCtx := context.TODO()
 
 		drainManager := upgrade.NewDrainManager(k8sInterface, upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder), log, eventRecorder)
 		drainSpec := &v1alpha1.DrainSpec{
@@ -101,49 +99,49 @@ var _ = Describe("DrainManager tests", func() {
 			TimeoutSecond:  1,
 			DeleteEmptyDir: true,
 		}
-		err := drainManager.ScheduleNodesDrain(ctx, &upgrade.DrainConfiguration{Nodes: nil, Spec: drainSpec})
+		err := drainManager.ScheduleNodesDrain(testCtx, &upgrade.DrainConfiguration{Nodes: nil, Spec: drainSpec})
 		Expect(err).To(Succeed())
 
 		time.Sleep(time.Second)
 	})
 	It("DrainManager should return error on nil drain spec", func() {
-		ctx := context.TODO()
+		testCtx := context.TODO()
 
 		node := createNode("node")
 
 		drainManager := upgrade.NewDrainManager(k8sInterface, upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder), log, eventRecorder)
 
 		nodeArray := []*corev1.Node{node}
-		err := drainManager.ScheduleNodesDrain(ctx, &upgrade.DrainConfiguration{Nodes: nodeArray, Spec: nil})
+		err := drainManager.ScheduleNodesDrain(testCtx, &upgrade.DrainConfiguration{Nodes: nodeArray, Spec: nil})
 		Expect(err).ToNot(Succeed())
 
 		time.Sleep(time.Second)
 
 		observedNode := &corev1.Node{}
-		err = k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, observedNode)
+		err = k8sClient.Get(testCtx, types.NamespacedName{Name: node.Name}, observedNode)
 		Expect(err).To(Succeed())
 		Expect(observedNode.Spec.Unschedulable).To(BeFalse())
 	})
 	It("DrainManager should skip drain on empty drain spec", func() {
-		ctx := context.TODO()
+		testCtx := context.TODO()
 
 		node := createNode("node")
 
 		drainManager := upgrade.NewDrainManager(k8sInterface, upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder), log, eventRecorder)
 
 		nodeArray := []*corev1.Node{node}
-		err := drainManager.ScheduleNodesDrain(ctx, &upgrade.DrainConfiguration{Nodes: nodeArray, Spec: &v1alpha1.DrainSpec{}})
+		err := drainManager.ScheduleNodesDrain(testCtx, &upgrade.DrainConfiguration{Nodes: nodeArray, Spec: &v1alpha1.DrainSpec{}})
 		Expect(err).To(Succeed())
 
 		time.Sleep(time.Second)
 
 		observedNode := &corev1.Node{}
-		err = k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, observedNode)
+		err = k8sClient.Get(testCtx, types.NamespacedName{Name: node.Name}, observedNode)
 		Expect(err).To(Succeed())
 		Expect(observedNode.Spec.Unschedulable).To(BeFalse())
 	})
 	It("DrainManager should skip drain if drain is disabled in the spec", func() {
-		ctx := context.TODO()
+		testCtx := context.TODO()
 
 		node := createNode("node")
 
@@ -151,13 +149,13 @@ var _ = Describe("DrainManager tests", func() {
 
 		nodeArray := []*corev1.Node{node}
 		err := drainManager.ScheduleNodesDrain(
-			ctx, &upgrade.DrainConfiguration{Nodes: nodeArray, Spec: &v1alpha1.DrainSpec{Enable: false}})
+			testCtx, &upgrade.DrainConfiguration{Nodes: nodeArray, Spec: &v1alpha1.DrainSpec{Enable: false}})
 		Expect(err).To(Succeed())
 
 		time.Sleep(time.Second)
 
 		observedNode := &corev1.Node{}
-		err = k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, observedNode)
+		err = k8sClient.Get(testCtx, types.NamespacedName{Name: node.Name}, observedNode)
 		Expect(err).To(Succeed())
 		Expect(observedNode.Spec.Unschedulable).To(BeFalse())
 	})

--- a/pkg/upgrade/mocks/PodManager.go
+++ b/pkg/upgrade/mocks/PodManager.go
@@ -54,19 +54,19 @@ func (_m *PodManager) GetDaemonsetControllerRevisionHash(ctx context.Context, da
 }
 
 // GetPodControllerRevisionHash provides a mock function with given fields: ctx, pod
-func (_m *PodManager) GetPodControllerRevisionHash(ctx context.Context, pod *corev1.Pod) (string, error) {
-	ret := _m.Called(ctx, pod)
+func (_m *PodManager) GetPodControllerRevisionHash(pod *corev1.Pod) (string, error) {
+	ret := _m.Called(pod)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(context.Context, *corev1.Pod) string); ok {
-		r0 = rf(ctx, pod)
+	if rf, ok := ret.Get(0).(func(*corev1.Pod) string); ok {
+		r0 = rf(pod)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *corev1.Pod) error); ok {
-		r1 = rf(ctx, pod)
+	if rf, ok := ret.Get(1).(func(*corev1.Pod) error); ok {
+		r1 = rf(pod)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/upgrade/node_upgrade_state_provider_test.go
+++ b/pkg/upgrade/node_upgrade_state_provider_test.go
@@ -17,33 +17,30 @@ limitations under the License.
 package upgrade_test
 
 import (
-	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/NVIDIA/k8s-operator-libs/pkg/upgrade"
+	upgrade "github.com/NVIDIA/k8s-operator-libs/pkg/upgrade"
 )
 
 var _ = Describe("NodeUpgradeStateProvider tests", func() {
-	var ctx context.Context
 	var id string
 	var node *corev1.Node
 
 	BeforeEach(func() {
-		ctx = context.TODO()
 		id = randSeq(5)
 		node = createNode(fmt.Sprintf("node-%s", id))
 	})
 	It("NodeUpgradeStateProvider should change node upgrade state and retrieve the latest node object", func() {
 		provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
 
-		err := provider.ChangeNodeUpgradeState(ctx, node, upgrade.UpgradeStateUpgradeRequired)
+		err := provider.ChangeNodeUpgradeState(testCtx, node, upgrade.UpgradeStateUpgradeRequired)
 		Expect(err).To(Succeed())
 
-		node, err = provider.GetNode(ctx, node.Name)
+		node, err = provider.GetNode(testCtx, node.Name)
 		Expect(err).To(Succeed())
 		Expect(node.Labels[upgrade.GetUpgradeStateLabelKey()]).To(Equal(upgrade.UpgradeStateUpgradeRequired))
 	})
@@ -51,10 +48,10 @@ var _ = Describe("NodeUpgradeStateProvider tests", func() {
 		provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
 
 		key := upgrade.GetUpgradeInitialStateAnnotationKey()
-		err := provider.ChangeNodeUpgradeAnnotation(ctx, node, key, "true")
+		err := provider.ChangeNodeUpgradeAnnotation(testCtx, node, key, "true")
 		Expect(err).To(Succeed())
 
-		node, err = provider.GetNode(ctx, node.Name)
+		node, err = provider.GetNode(testCtx, node.Name)
 		Expect(err).To(Succeed())
 		Expect(node.Annotations[key]).To(Equal("true"))
 	})
@@ -62,10 +59,10 @@ var _ = Describe("NodeUpgradeStateProvider tests", func() {
 		provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
 
 		key := upgrade.GetUpgradeInitialStateAnnotationKey()
-		err := provider.ChangeNodeUpgradeAnnotation(ctx, node, key, "null")
+		err := provider.ChangeNodeUpgradeAnnotation(testCtx, node, key, "null")
 		Expect(err).To(Succeed())
 
-		node, err = provider.GetNode(ctx, node.Name)
+		node, err = provider.GetNode(testCtx, node.Name)
 		Expect(err).To(Succeed())
 		_, exist := node.Annotations[key]
 		Expect(exist).To(Equal(false))

--- a/pkg/upgrade/pod_manager.go
+++ b/pkg/upgrade/pod_manager.go
@@ -55,7 +55,7 @@ type PodManager interface {
 	SchedulePodsRestart(ctx context.Context, pods []*corev1.Pod) error
 	SchedulePodEviction(ctx context.Context, config *PodManagerConfig) error
 	GetPodDeletionFilter() PodDeletionFilter
-	GetPodControllerRevisionHash(ctx context.Context, pod *corev1.Pod) (string, error)
+	GetPodControllerRevisionHash(pod *corev1.Pod) (string, error)
 	GetDaemonsetControllerRevisionHash(ctx context.Context, daemonset *appsv1.DaemonSet) (string, error)
 }
 
@@ -81,10 +81,7 @@ func (m *PodManagerImpl) GetPodDeletionFilter() PodDeletionFilter {
 }
 
 // GetPodControllerRevisionHash returns the Pod Controller Revision Hash from its labels
-// TODO: Drop ctx as it's not used
-//
-//nolint:revive
-func (m *PodManagerImpl) GetPodControllerRevisionHash(ctx context.Context, pod *corev1.Pod) (string, error) {
+func (m *PodManagerImpl) GetPodControllerRevisionHash(pod *corev1.Pod) (string, error) {
 	if hash, ok := pod.Labels[PodControllerRevisionHashLabelKey]; ok {
 		return hash, nil
 	}

--- a/pkg/upgrade/safe_driver_load_manager_test.go
+++ b/pkg/upgrade/safe_driver_load_manager_test.go
@@ -17,28 +17,24 @@ limitations under the License.
 package upgrade_test
 
 import (
-	"context"
 	"fmt"
 
+	"github.com/NVIDIA/k8s-operator-libs/pkg/upgrade"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/NVIDIA/k8s-operator-libs/pkg/upgrade"
 )
 
 var _ = Describe("SafeDriverLoadManager", func() {
 	var (
 		node *corev1.Node
-		ctx  context.Context
 		id   string
 		mgr  upgrade.SafeDriverLoadManager
 	)
 	BeforeEach(func() {
-		ctx = context.Background()
 		// generate random id for test
 		id = randSeq(5)
 		// create k8s objects
@@ -48,28 +44,28 @@ var _ = Describe("SafeDriverLoadManager", func() {
 	It("IsWaitingForSafeDriverLoad", func() {
 		annotationKey := upgrade.GetUpgradeDriverWaitForSafeLoadAnnotationKey()
 		Expect(k8sClient.Patch(
-			ctx, node, client.RawPatch(types.StrategicMergePatchType,
+			testCtx, node, client.RawPatch(types.StrategicMergePatchType,
 				[]byte(fmt.Sprintf(`{"metadata":{"annotations":{%q: "true"}}}`,
 					annotationKey))))).NotTo(HaveOccurred())
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, node)).NotTo(HaveOccurred())
-		Expect(mgr.IsWaitingForSafeDriverLoad(ctx, node)).To(BeTrue())
+		Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: node.Name}, node)).NotTo(HaveOccurred())
+		Expect(mgr.IsWaitingForSafeDriverLoad(testCtx, node)).To(BeTrue())
 		Expect(k8sClient.Patch(
-			ctx, node, client.RawPatch(types.StrategicMergePatchType,
+			testCtx, node, client.RawPatch(types.StrategicMergePatchType,
 				[]byte(fmt.Sprintf(`{"metadata":{"annotations":{%q: null}}}`,
 					annotationKey))))).NotTo(HaveOccurred())
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, node)).NotTo(HaveOccurred())
-		Expect(mgr.IsWaitingForSafeDriverLoad(ctx, node)).To(BeFalse())
+		Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: node.Name}, node)).NotTo(HaveOccurred())
+		Expect(mgr.IsWaitingForSafeDriverLoad(testCtx, node)).To(BeFalse())
 	})
 	It("UnblockLoading", func() {
 		annotationKey := upgrade.GetUpgradeDriverWaitForSafeLoadAnnotationKey()
 		Expect(k8sClient.Patch(
-			ctx, node, client.RawPatch(types.StrategicMergePatchType,
+			testCtx, node, client.RawPatch(types.StrategicMergePatchType,
 				[]byte(fmt.Sprintf(`{"metadata":{"annotations":{%q: "true"}}}`,
 					annotationKey))))).NotTo(HaveOccurred())
-		Expect(mgr.UnblockLoading(ctx, node)).NotTo(HaveOccurred())
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, node)).NotTo(HaveOccurred())
+		Expect(mgr.UnblockLoading(testCtx, node)).NotTo(HaveOccurred())
+		Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: node.Name}, node)).NotTo(HaveOccurred())
 		Expect(node.Annotations[annotationKey]).To(BeEmpty())
 		// should not fail when called on non blocked node
-		Expect(mgr.UnblockLoading(ctx, node)).NotTo(HaveOccurred())
+		Expect(mgr.UnblockLoading(testCtx, node)).NotTo(HaveOccurred())
 	})
 })

--- a/pkg/upgrade/upgrade_inplace.go
+++ b/pkg/upgrade/upgrade_inplace.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/NVIDIA/k8s-operator-libs/api/upgrade/v1alpha1"
+	"github.com/NVIDIA/k8s-operator-libs/pkg/consts"
+)
+
+// InplaceNodeStateManagerImpl contains concrete implementations for distinct inplace upgrade mode
+type InplaceNodeStateManagerImpl struct {
+	*CommonUpgradeManagerImpl
+}
+
+// NewClusterUpgradeStateManager creates a new instance of InplaceNodeStateManagerImpl
+func NewInplaceNodeStateManagerImpl(commonmanager *CommonUpgradeManagerImpl) (ProcessNodeStateManager,
+	error) {
+	manager := &InplaceNodeStateManagerImpl{
+		CommonUpgradeManagerImpl: commonmanager,
+	}
+	return manager, nil
+}
+
+// ProcessUpgradeRequiredNodes processes UpgradeStateUpgradeRequired nodes and moves them to UpgradeStateCordonRequired
+// until the limit on max parallel upgrades is reached.
+func (m *InplaceNodeStateManagerImpl) ProcessUpgradeRequiredNodes(
+	ctx context.Context, currentClusterState *ClusterUpgradeState,
+	upgradePolicy *v1alpha1.DriverUpgradePolicySpec) error {
+	var err error
+
+	totalNodes := m.GetTotalManagedNodes(currentClusterState)
+	upgradesInProgress := m.GetUpgradesInProgress(currentClusterState)
+	currentUnavailableNodes := m.GetCurrentUnavailableNodes(currentClusterState)
+	maxUnavailable := totalNodes
+
+	if upgradePolicy.MaxUnavailable != nil {
+		maxUnavailable, err = intstr.GetScaledValueFromIntOrPercent(upgradePolicy.MaxUnavailable, totalNodes, true)
+		if err != nil {
+			m.Log.V(consts.LogLevelError).Error(err, "Failed to compute maxUnavailable from the current total nodes")
+			return err
+		}
+	}
+	upgradesAvailable := m.GetUpgradesAvailable(currentClusterState, upgradePolicy.MaxParallelUpgrades,
+		maxUnavailable)
+	m.Log.V(consts.LogLevelInfo).Info("Upgrades in progress",
+		"currently in progress", upgradesInProgress,
+		"max parallel upgrades", upgradePolicy.MaxParallelUpgrades,
+		"upgrade slots available", upgradesAvailable,
+		"currently unavailable nodes", currentUnavailableNodes,
+		"total number of nodes", totalNodes,
+		"maximum nodes that can be unavailable", maxUnavailable)
+
+	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateUpgradeRequired] {
+		if m.IsUpgradeRequested(nodeState.Node) {
+			// Make sure to remove the upgrade-requested annotation
+			err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeAnnotation(ctx, nodeState.Node,
+				GetUpgradeRequestedAnnotationKey(), "null")
+			if err != nil {
+				m.Log.V(consts.LogLevelError).Error(
+					err, "Failed to delete node upgrade-requested annotation")
+				return err
+			}
+		}
+		if m.SkipNodeUpgrade(nodeState.Node) {
+			m.Log.V(consts.LogLevelInfo).Info("Node is marked for skipping upgrades", "node", nodeState.Node.Name)
+			continue
+		}
+
+		if upgradesAvailable <= 0 {
+			// when no new node upgrades are available, progess with manually cordoned nodes
+			if m.IsNodeUnschedulable(nodeState.Node) {
+				m.Log.V(consts.LogLevelDebug).Info("Node is already cordoned, progressing for driver upgrade",
+					"node", nodeState.Node.Name)
+			} else {
+				m.Log.V(consts.LogLevelDebug).Info("Node upgrade limit reached, pausing further upgrades",
+					"node", nodeState.Node.Name)
+				continue
+			}
+		}
+
+		err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateCordonRequired)
+		if err == nil {
+			upgradesAvailable--
+			m.Log.V(consts.LogLevelInfo).Info("Node waiting for cordon",
+				"node", nodeState.Node.Name)
+		} else {
+			m.Log.V(consts.LogLevelError).Error(
+				err, "Failed to change node upgrade state", "state", UpgradeStateCordonRequired)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ProcessNodeMaintenanceRequiredNodes is a used to satisfy ProcessNodeStateManager interface
+func (m *InplaceNodeStateManagerImpl) ProcessNodeMaintenanceRequiredNodes(ctx context.Context,
+	currentClusterState *ClusterUpgradeState) error {
+	_ = ctx
+	_ = currentClusterState
+	return nil
+}
+
+// ProcessUncordonRequiredNodes processes UpgradeStateUncordonRequired nodes,
+// uncordons them and moves them to UpgradeStateDone state
+func (m *InplaceNodeStateManagerImpl) ProcessUncordonRequiredNodes(
+	ctx context.Context, currentClusterState *ClusterUpgradeState) error {
+	m.Log.V(consts.LogLevelInfo).Info("ProcessUncordonRequiredNodes")
+
+	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateUncordonRequired] {
+		// skip in case node had undergone uncordon by maintenance operator
+		if nodeState.NodeMaintenance != nil {
+			continue
+		}
+		err := m.CordonManager.Uncordon(ctx, nodeState.Node)
+		if err != nil {
+			m.Log.V(consts.LogLevelWarning).Error(
+				err, "Node uncordon failed", "node", nodeState.Node)
+			return err
+		}
+		err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateDone)
+		if err != nil {
+			m.Log.V(consts.LogLevelError).Error(
+				err, "Failed to change node upgrade state", "state", UpgradeStateDone)
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/upgrade/upgrade_requestor.go
+++ b/pkg/upgrade/upgrade_requestor.go
@@ -1,0 +1,441 @@
+/*
+Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"slices"
+
+	//nolint:depguard
+	maintenancev1alpha1 "github.com/Mellanox/maintenance-operator/api/v1alpha1"
+	"github.com/go-logr/logr"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/NVIDIA/k8s-operator-libs/api/upgrade/v1alpha1"
+	"github.com/NVIDIA/k8s-operator-libs/pkg/consts"
+)
+
+const (
+	// MaintenanceOPEvictionGPU is a default filter for GPU OP pods eviction
+	MaintenanceOPEvictionGPU = "nvidia.com/gpu-*"
+	// MaintenanceOPEvictionRDMA is a default filter for Network OP pods eviction
+	MaintenanceOPEvictionRDMA = "nvidia.com/rdma*"
+)
+
+var (
+	ErrNodeMaintenanceUpgradeDisabled = errors.New("node maintenance upgrade mode is disabled")
+	defaultNodeMaintenance            *maintenancev1alpha1.NodeMaintenance
+	Scheme                            = runtime.NewScheme()
+)
+
+type ConditionChangedPredicate struct {
+	predicate.Funcs
+	requestorID string
+
+	log logr.Logger
+}
+
+type RequestorOptions struct {
+	// UseMaintenanceOperator enables requestor upgrade mode
+	UseMaintenanceOperator bool
+	// MaintenanceOPRequestorID is the requestor ID for maintenance operator
+	MaintenanceOPRequestorID string
+	// MaintenanceOPRequestorNS is a user defined namespace which nodeMaintennace
+	// objects will be created
+	MaintenanceOPRequestorNS string
+	// MaintenanceOPPodEvictionFilter is a filter to be used for pods eviction
+	// by maintenance operator
+	MaintenanceOPPodEvictionFilter []maintenancev1alpha1.PodEvictionFiterEntry
+}
+
+// RequestorNodeStateManagerImpl contains concrete implementations for distinct requestor
+// (e.g. maintenance OP) upgrade mode
+type RequestorNodeStateManagerImpl struct {
+	*CommonUpgradeManagerImpl
+	opts RequestorOptions
+}
+
+// NewConditionChangedPredicate creates a new ConditionChangedPredicate
+func NewConditionChangedPredicate(log logr.Logger, requestorID string) ConditionChangedPredicate {
+	return ConditionChangedPredicate{
+		Funcs:       predicate.Funcs{},
+		log:         log,
+		requestorID: requestorID,
+	}
+}
+
+// Update implements Predicate.
+func (p ConditionChangedPredicate) Update(e event.TypedUpdateEvent[client.Object]) bool {
+	p.log.V(consts.LogLevelDebug).Info("ConditionChangedPredicate Update event")
+
+	if e.ObjectOld == nil {
+		p.log.Error(nil, "old object is nil in update event, ignoring event.")
+		return false
+	}
+	if e.ObjectNew == nil {
+		p.log.Error(nil, "new object is nil in update event, ignoring event.")
+		return false
+	}
+
+	oldO, ok := e.ObjectOld.(*maintenancev1alpha1.NodeMaintenance)
+	if !ok {
+		p.log.Error(nil, "failed to cast old object to NodeMaintenance in update event, ignoring event.")
+		return false
+	}
+
+	newO, ok := e.ObjectNew.(*maintenancev1alpha1.NodeMaintenance)
+	if !ok {
+		p.log.Error(nil, "failed to cast new object to NodeMaintenance in update event, ignoring event.")
+		return false
+	}
+
+	// check for matching requestor ID
+	if newO.Spec.RequestorID != p.requestorID {
+		return false
+	}
+
+	cmpByType := func(a, b metav1.Condition) int {
+		return cmp.Compare(a.Type, b.Type)
+	}
+
+	// sort old and new obj.Status.Conditions so they can be compared using DeepEqual
+	slices.SortFunc(oldO.Status.Conditions, cmpByType)
+	slices.SortFunc(newO.Status.Conditions, cmpByType)
+
+	condChanged := !reflect.DeepEqual(oldO.Status.Conditions, newO.Status.Conditions)
+	// Check if the object is marked for deletion
+	deleting := len(newO.Finalizers) == 0 && len(oldO.Finalizers) > 0
+	deleting = deleting && !newO.DeletionTimestamp.IsZero()
+	enqueue := condChanged || deleting
+
+	p.log.V(consts.LogLevelDebug).Info("update event for NodeMaintenance",
+		"name", newO.Name, "namespace", newO.Namespace,
+		"condition-changed", condChanged,
+		"deleting", deleting, "enqueue-request", enqueue)
+
+	return enqueue
+}
+
+func SetDefaultNodeMaintenance(opts RequestorOptions,
+	upgradePolicy *v1alpha1.DriverUpgradePolicySpec) {
+	drainSpec, podCompletion := convertV1Alpha1ToMaintenance(upgradePolicy, opts)
+	defaultNodeMaintenance = &maintenancev1alpha1.NodeMaintenance{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: opts.MaintenanceOPRequestorNS,
+		},
+		Spec: maintenancev1alpha1.NodeMaintenanceSpec{
+			RequestorID:          opts.MaintenanceOPRequestorID,
+			WaitForPodCompletion: podCompletion,
+			DrainSpec:            drainSpec,
+		},
+	}
+}
+
+func (m *RequestorNodeStateManagerImpl) NewNodeMaintenance(nodeName string) *maintenancev1alpha1.NodeMaintenance {
+	nm := defaultNodeMaintenance.DeepCopy()
+	nm.Name = nodeName
+	nm.Spec.NodeName = nodeName
+
+	return nm
+}
+
+// CreateNodeMaintenance creates nodeMaintenance obj for designated node upgrade-required state
+func (m *RequestorNodeStateManagerImpl) CreateNodeMaintenance(ctx context.Context,
+	nodeState *NodeUpgradeState) error {
+	nm := m.NewNodeMaintenance(nodeState.Node.Name)
+	nodeState.NodeMaintenance = nm
+	m.Log.V(consts.LogLevelInfo).Info("creating node maintenance", nodeState.Node.Name, nm.Name)
+	err := m.K8sClient.Create(ctx, nm, &client.CreateOptions{})
+	if err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			m.Log.V(consts.LogLevelWarning).Info("nodeMaintenance", nm.Name, "already exists")
+			return nil
+		}
+		return fmt.Errorf("failed to create node maintenance '%+v'. %v", nm, err)
+	}
+
+	return nil
+}
+
+// GetNodeMaintenanceObj creates nodeMaintenance obj for designated node upgrade-required state
+func (m *RequestorNodeStateManagerImpl) GetNodeMaintenanceObj(ctx context.Context,
+	nodeName string) (client.Object, error) {
+	nm := &maintenancev1alpha1.NodeMaintenance{}
+	err := m.K8sClient.Get(ctx, types.NamespacedName{
+		Name: nodeName, Namespace: m.opts.MaintenanceOPRequestorNS},
+		nm, &client.GetOptions{})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, err
+		}
+		// explicitly return nil so returned interface is truly nil
+		//nolint:nilnil // this is intentional: returning nil obj and nil error to indicate "not found"
+		return nil, nil
+	}
+	return nm, nil
+}
+
+// DeleteNodeMaintenance requests to delete nodeMaintenance obj
+func (m *RequestorNodeStateManagerImpl) DeleteNodeMaintenance(ctx context.Context,
+	nodeState *NodeUpgradeState) error {
+	_, err := validateNodeMaintenance(nodeState)
+	if err != nil {
+		return err
+	}
+	nm := &maintenancev1alpha1.NodeMaintenance{}
+	err = m.K8sClient.Get(ctx, types.NamespacedName{Name: nodeState.Node.Name,
+		Namespace: m.opts.MaintenanceOPRequestorNS},
+		nm, &client.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	// send deletion request assuming maintenance OP will handle actual obj deletion
+	// avoid deletion if timestamp was already set
+	if nm.DeletionTimestamp == nil {
+		err = m.K8sClient.Delete(ctx, nm)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateNodeMaintenance(nodeState *NodeUpgradeState) (*maintenancev1alpha1.NodeMaintenance, error) {
+	if nodeState.NodeMaintenance == nil {
+		return nil, fmt.Errorf("missing nodeMaintenance for specified nodeUpgradeState. %v", nodeState)
+	}
+	nm, ok := nodeState.NodeMaintenance.(*maintenancev1alpha1.NodeMaintenance)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast object to NodeMaintenance. %v", nodeState.NodeMaintenance)
+	}
+	return nm, nil
+}
+
+// NewRequestorNodeStateManagerImpl creates a new instance of (requestor) RequestorNodeStateManagerImpl
+func NewRequestorNodeStateManagerImpl(
+	common *CommonUpgradeManagerImpl,
+	opts RequestorOptions) (ProcessNodeStateManager, error) {
+	if !opts.UseMaintenanceOperator {
+		common.Log.V(consts.LogLevelInfo).Info("node maintenance upgrade mode is disabled")
+		return nil, ErrNodeMaintenanceUpgradeDisabled
+	}
+	manager := &RequestorNodeStateManagerImpl{
+		opts:                     opts,
+		CommonUpgradeManagerImpl: common,
+	}
+
+	return manager, nil
+}
+
+// ProcessUpgradeRequiredNodes processes UpgradeStateUpgradeRequired nodes and moves them to UpgradeStateCordonRequired
+// until the limit on max parallel upgrades is reached.
+func (m *RequestorNodeStateManagerImpl) ProcessUpgradeRequiredNodes(
+	ctx context.Context, currentClusterState *ClusterUpgradeState,
+	upgradePolicy *v1alpha1.DriverUpgradePolicySpec) error {
+	m.Log.V(consts.LogLevelInfo).Info("ProcessUpgradeRequiredNodes")
+
+	SetDefaultNodeMaintenance(m.opts, upgradePolicy)
+	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateUpgradeRequired] {
+		if m.IsUpgradeRequested(nodeState.Node) {
+			// Make sure to remove the upgrade-requested annotation
+			err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeAnnotation(ctx, nodeState.Node,
+				GetUpgradeRequestedAnnotationKey(), "null")
+			if err != nil {
+				m.Log.V(consts.LogLevelError).Error(
+					err, "Failed to delete node upgrade-requested annotation")
+				return err
+			}
+		}
+		if m.SkipNodeUpgrade(nodeState.Node) {
+			m.Log.V(consts.LogLevelInfo).Info("Node is marked for skipping upgrades", "node", nodeState.Node.Name)
+			continue
+		}
+
+		err := m.CreateNodeMaintenance(ctx, nodeState)
+		if err != nil {
+			m.Log.V(consts.LogLevelError).Error(err, "failed to create nodeMaintenance")
+			return err
+		}
+
+		annotationKey := GetUpgradeRequestorModeAnnotationKey()
+		err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeAnnotation(ctx, nodeState.Node, annotationKey, "true")
+		if err != nil {
+			return fmt.Errorf("failed annotate node for 'upgrade-requestor-mode'. %v", err)
+		}
+		// update node state to 'node-maintenance-required'
+		err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node,
+			UpgradeStateNodeMaintenanceRequired)
+		if err != nil {
+			return fmt.Errorf("failed to update node state. %v", err)
+		}
+	}
+
+	return nil
+}
+
+// ProcessNodeMaintenanceRequiredNodes processes UpgradeStatePostMaintenanceRequired
+// by adding UpgradeStatePodRestartRequired under existing UpgradeStatePodRestartRequired nodes list.
+// the motivation is later to replace ProcessPodRestartNodes to a generic post node operation
+// while using maintenance operator (e.g. post-maintenance-required)
+func (m *RequestorNodeStateManagerImpl) ProcessNodeMaintenanceRequiredNodes(ctx context.Context,
+	currentClusterState *ClusterUpgradeState) error {
+	m.Log.V(consts.LogLevelInfo).Info("ProcessNodeMaintenanceRequiredNodes")
+	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateNodeMaintenanceRequired] {
+		if nodeState.NodeMaintenance == nil {
+			if _, ok := nodeState.Node.Annotations[GetUpgradeRequestorModeAnnotationKey()]; !ok {
+				m.Log.V(consts.LogLevelWarning).Info("missing node annotation", "node", nodeState.Node.Name,
+					"annotations", nodeState.Node.Annotations)
+			}
+			// update node state back to 'upgrade-required' in case of missing nodeMaintenance obj
+			err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node,
+				UpgradeStateUpgradeRequired)
+			if err != nil {
+				return fmt.Errorf("failed to update node state. %v", err)
+			}
+			continue
+		}
+		nm, ok := nodeState.NodeMaintenance.(*maintenancev1alpha1.NodeMaintenance)
+		if !ok {
+			return fmt.Errorf("failed to cast object to NodeMaintenance. %v", nodeState.NodeMaintenance)
+		}
+		cond := meta.FindStatusCondition(nm.Status.Conditions, maintenancev1alpha1.ConditionReasonReady)
+		if cond != nil {
+			if cond.Reason == maintenancev1alpha1.ConditionReasonReady {
+				m.Log.V(consts.LogLevelDebug).Info("node maintenance operation completed", nm.Spec.NodeName, cond.Reason)
+				// update node state to 'pod-restart-required'
+				err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node,
+					UpgradeStatePodRestartRequired)
+				if err != nil {
+					return fmt.Errorf("failed to update node state. %v", err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (m *RequestorNodeStateManagerImpl) ProcessUncordonRequiredNodes(
+	ctx context.Context, currentClusterState *ClusterUpgradeState) error {
+	m.Log.V(consts.LogLevelInfo).Info("ProcessUncordonRequiredNodes")
+
+	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateUncordonRequired] {
+		m.Log.V(consts.LogLevelDebug).Info("deleting node maintenance",
+			nodeState.NodeMaintenance.GetName(), nodeState.NodeMaintenance.GetNamespace())
+		// skip in case node undergoes uncordon by inplace flow
+		if nodeState.NodeMaintenance == nil {
+			return nil
+		}
+		err := m.DeleteNodeMaintenance(ctx, nodeState)
+		if err != nil {
+			m.Log.V(consts.LogLevelWarning).Error(
+				err, "Node uncordon failed", "node", nodeState.Node)
+			return err
+		}
+		// this means that node maintenance obj has been deleted
+		err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node,
+			UpgradeStateDone)
+		if err != nil {
+			return fmt.Errorf("failed to update node state. %v", err)
+		}
+		// remove requestor upgrade annotation
+		err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeAnnotation(ctx,
+			nodeState.Node, GetUpgradeRequestorModeAnnotationKey(), "null")
+		if err != nil {
+			return fmt.Errorf("failed to remove '%s' annotation . %v", GetUpgradeRequestorModeAnnotationKey(), err)
+		}
+		err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateDone)
+		if err != nil {
+			m.Log.V(consts.LogLevelError).Error(
+				err, "Failed to change node upgrade state", "state", UpgradeStateDone)
+			return err
+		}
+	}
+	return nil
+}
+
+// convertV1Alpha1ToMaintenance explicitly converts v1alpha1.DriverUpgradePolicySpec
+// to maintenancev1alpha1.DrainSpec and maintenancev1alpha1.WaitForPodCompletionSpec and
+func convertV1Alpha1ToMaintenance(upgradePolicy *v1alpha1.DriverUpgradePolicySpec,
+	opts RequestorOptions) (*maintenancev1alpha1.DrainSpec,
+	*maintenancev1alpha1.WaitForPodCompletionSpec) {
+	var podComplition *maintenancev1alpha1.WaitForPodCompletionSpec
+	if upgradePolicy == nil {
+		return nil, nil
+	}
+	drainSpec := &maintenancev1alpha1.DrainSpec{}
+	if upgradePolicy.DrainSpec != nil {
+		drainSpec.Force = upgradePolicy.DrainSpec.Force
+		drainSpec.PodSelector = upgradePolicy.DrainSpec.PodSelector
+		//nolint:gosec // G115: suppress potential integer overflow conversion warning
+		drainSpec.TimeoutSecond = int32(upgradePolicy.DrainSpec.TimeoutSecond)
+		drainSpec.DeleteEmptyDir = upgradePolicy.DrainSpec.DeleteEmptyDir
+	}
+	if upgradePolicy.PodDeletion != nil {
+		drainSpec.PodEvictionFilters = opts.MaintenanceOPPodEvictionFilter
+	}
+	if upgradePolicy.WaitForCompletion != nil {
+		podComplition = &maintenancev1alpha1.WaitForPodCompletionSpec{
+			PodSelector: upgradePolicy.WaitForCompletion.PodSelector,
+			//nolint:gosec // G115: suppress potential integer overflow conversion warning
+			TimeoutSecond: int32(upgradePolicy.WaitForCompletion.TimeoutSecond),
+		}
+	}
+
+	return drainSpec, podComplition
+}
+
+// GetRequestorEnvs returns requstor upgrade related options according to provided environment variables
+func GetRequestorOptsFromEnvs() RequestorOptions {
+	opts := RequestorOptions{}
+	if os.Getenv("MAINTENANCE_OPERATOR_ENABLED") == "true" {
+		opts.UseMaintenanceOperator = true
+	}
+	if os.Getenv("MAINTENANCE_OPERATOR_REQUESTOR_NAMESPACE") != "" {
+		opts.MaintenanceOPRequestorNS = os.Getenv("MAINTENANCE_OPERATOR_REQUESTOR_NAMESPACE")
+	} else {
+		opts.MaintenanceOPRequestorNS = "default"
+	}
+	if os.Getenv("MAINTENANCE_OPERATOR_REQUESTOR_ID") != "" {
+		opts.MaintenanceOPRequestorID = os.Getenv("MAINTENANCE_OPERATOR_REQUESTOR_ID")
+	} else {
+		opts.MaintenanceOPRequestorID = "nvidia.operator.com"
+	}
+	return opts
+}
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
+	utilruntime.Must(maintenancev1alpha1.AddToScheme(Scheme))
+}

--- a/pkg/upgrade/upgrade_state.go
+++ b/pkg/upgrade/upgrade_state.go
@@ -23,48 +23,26 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1alpha1 "github.com/NVIDIA/k8s-operator-libs/api/upgrade/v1alpha1"
+	"github.com/NVIDIA/k8s-operator-libs/api/upgrade/v1alpha1"
 	"github.com/NVIDIA/k8s-operator-libs/pkg/consts"
 )
 
-// NodeUpgradeState contains a mapping between a node,
-// the driver POD running on them and the daemon set, controlling this pod
-type NodeUpgradeState struct {
-	Node            *corev1.Node
-	DriverPod       *corev1.Pod
-	DriverDaemonSet *appsv1.DaemonSet
-}
-
-// IsOrphanedPod returns true if Pod is not associated to a DaemonSet
-func (nus *NodeUpgradeState) IsOrphanedPod() bool {
-	return nus.DriverDaemonSet == nil
-}
-
-// ClusterUpgradeState contains a snapshot of the driver upgrade state in the cluster
-// It contains driver upgrade policy and mappings between nodes and their upgrade state
-// Nodes are grouped together with the driver POD running on them and the daemon set, controlling this pod
-// This state is then used as an input for the ClusterUpgradeStateManager
-type ClusterUpgradeState struct {
-	NodeStates map[string][]*NodeUpgradeState
-}
-
-// NewClusterUpgradeState creates an empty ClusterUpgradeState object
-func NewClusterUpgradeState() ClusterUpgradeState {
-	return ClusterUpgradeState{NodeStates: make(map[string][]*NodeUpgradeState)}
-}
-
 // ClusterUpgradeStateManager is an interface for performing cluster upgrades of driver containers
-//
-//nolint:interfacebloat
 type ClusterUpgradeStateManager interface {
+	CommonUpgradeStateManager
+	// WithPodDeletionEnabled provides an option to enable the optional 'pod-deletion'
+	// state and pass a custom PodDeletionFilter to use
+	WithPodDeletionEnabled(filter PodDeletionFilter) ClusterUpgradeStateManager
+	// WithValidationEnabled provides an option to enable the optional 'validation' state
+	// and pass a podSelector to specify which pods are performing the validation
+	WithValidationEnabled(podSelector string) ClusterUpgradeStateManager
+	// BuildState builds a point-in-time snapshot of the driver upgrade state in the cluster.
+	BuildState(ctx context.Context, namespace string,
+		driverLabels map[string]string) (*ClusterUpgradeState, error)
 	// ApplyState receives a complete cluster upgrade state and, based on upgrade policy, processes each node's state.
 	// Based on the current state of the node, it is calculated if the node can be moved to the next state right now
 	// or whether any actions need to be scheduled for the node to move to the next state.
@@ -72,142 +50,49 @@ type ClusterUpgradeStateManager interface {
 	// ApplyState would be called again and complete the processing - all the decisions are based on the input data.
 	ApplyState(ctx context.Context,
 		currentState *ClusterUpgradeState, upgradePolicy *v1alpha1.DriverUpgradePolicySpec) (err error)
-	// BuildState builds a point-in-time snapshot of the driver upgrade state in the cluster.
-	BuildState(ctx context.Context, namespace string, driverLabels map[string]string) (*ClusterUpgradeState, error)
-	// GetTotalManagedNodes returns the total count of nodes managed for driver upgrades
-	GetTotalManagedNodes(ctx context.Context, currentState *ClusterUpgradeState) int
-	// GetUpgradesInProgress returns count of nodes on which upgrade is in progress
-	GetUpgradesInProgress(ctx context.Context, currentState *ClusterUpgradeState) int
-	// GetUpgradesDone returns count of nodes on which upgrade is complete
-	GetUpgradesDone(ctx context.Context, currentState *ClusterUpgradeState) int
-	// GetUpgradesAvailable returns count of nodes on which upgrade can be done
-	GetUpgradesAvailable(ctx context.Context,
-		currentState *ClusterUpgradeState, maxParallelUpgrades int, maxUnavailable int) int
-	// GetUpgradesFailed returns count of nodes on which upgrades have failed
-	GetUpgradesFailed(ctx context.Context, currentState *ClusterUpgradeState) int
-	// GetUpgradesPending returns count of nodes on which are marked for upgrades and upgrade is pending
-	GetUpgradesPending(ctx context.Context, currentState *ClusterUpgradeState) int
-	// WithPodDeletionEnabled provides an option to enable the optional 'pod-deletion'
-	// state and pass a custom PodDeletionFilter to use
-	WithPodDeletionEnabled(filter PodDeletionFilter) ClusterUpgradeStateManager
-	// WithValidationEnabled provides an option to enable the optional 'validation' state
-	// and pass a podSelector to specify which pods are performing the validation
-	WithValidationEnabled(podSelector string) ClusterUpgradeStateManager
-	// IsPodDeletionEnabled returns true if 'pod-deletion' state is enabled
-	IsPodDeletionEnabled() bool
-	// IsValidationEnabled returns true if 'validation' state is enabled
-	IsValidationEnabled() bool
 }
 
 // ClusterUpgradeStateManagerImpl serves as a state machine for the ClusterUpgradeState
 // It processes each node and based on its state schedules the required jobs to change their state to the next one
 type ClusterUpgradeStateManagerImpl struct {
-	Log           logr.Logger
-	K8sClient     client.Client
-	K8sInterface  kubernetes.Interface
-	EventRecorder record.EventRecorder
-
-	DrainManager             DrainManager
-	PodManager               PodManager
-	CordonManager            CordonManager
-	NodeUpgradeStateProvider NodeUpgradeStateProvider
-	ValidationManager        ValidationManager
-	SafeDriverLoadManager    SafeDriverLoadManager
-
-	// optional states
-	podDeletionStateEnabled bool
-	validationStateEnabled  bool
+	*CommonUpgradeManagerImpl
+	inplace   ProcessNodeStateManager
+	requestor ProcessNodeStateManager
+	opts      StateOptions
 }
 
 // NewClusterUpgradeStateManager creates a new instance of ClusterUpgradeStateManagerImpl
 func NewClusterUpgradeStateManager(
 	log logr.Logger,
 	k8sConfig *rest.Config,
-	eventRecorder record.EventRecorder) (ClusterUpgradeStateManager, error) {
-	k8sClient, err := client.New(k8sConfig, client.Options{Scheme: scheme.Scheme})
+	eventRecorder record.EventRecorder,
+	opts StateOptions) (ClusterUpgradeStateManager, error) {
+	commonmanager, err := NewCommonUpgradeStateManager(log, k8sConfig, Scheme, eventRecorder)
 	if err != nil {
-		return nil, fmt.Errorf("error creating k8s client: %v", err)
+		return nil, fmt.Errorf("failed to create commonmanager upgrade state manager. %v", err)
+	}
+	requestor, err := NewRequestorNodeStateManagerImpl(commonmanager, opts.Requestor)
+	if err != nil && err != ErrNodeMaintenanceUpgradeDisabled {
+		return nil, fmt.Errorf("failed to create requestor upgrade state manager. %v", err)
 	}
 
-	k8sInterface, err := kubernetes.NewForConfig(k8sConfig)
+	inplace, err := NewInplaceNodeStateManagerImpl(commonmanager)
 	if err != nil {
-		return nil, fmt.Errorf("error creating k8s interface: %v", err)
+		return nil, fmt.Errorf("failed to create inplace upgrade state manager. %v", err)
 	}
 
-	nodeUpgradeStateProvider := NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
 	manager := &ClusterUpgradeStateManagerImpl{
-		Log:                      log,
-		K8sClient:                k8sClient,
-		K8sInterface:             k8sInterface,
-		EventRecorder:            eventRecorder,
-		DrainManager:             NewDrainManager(k8sInterface, nodeUpgradeStateProvider, log, eventRecorder),
-		PodManager:               NewPodManager(k8sInterface, nodeUpgradeStateProvider, log, nil, eventRecorder),
-		CordonManager:            NewCordonManager(k8sInterface, log),
-		NodeUpgradeStateProvider: nodeUpgradeStateProvider,
-		ValidationManager:        NewValidationManager(k8sInterface, log, eventRecorder, nodeUpgradeStateProvider, ""),
-		SafeDriverLoadManager:    NewSafeDriverLoadManager(nodeUpgradeStateProvider, log),
+		CommonUpgradeManagerImpl: commonmanager,
+		requestor:                requestor,
+		inplace:                  inplace,
+		opts:                     opts,
 	}
+
 	return manager, nil
 }
 
-// WithPodDeletionEnabled provides an option to enable the optional 'pod-deletion' state and pass a custom
-// PodDeletionFilter to use
-func (m *ClusterUpgradeStateManagerImpl) WithPodDeletionEnabled(filter PodDeletionFilter) ClusterUpgradeStateManager {
-	if filter == nil {
-		m.Log.V(consts.LogLevelWarning).Info("Cannot enable PodDeletion state as PodDeletionFilter is nil")
-		return m
-	}
-	m.PodManager = NewPodManager(m.K8sInterface, m.NodeUpgradeStateProvider, m.Log, filter, m.EventRecorder)
-	m.podDeletionStateEnabled = true
-	return m
-}
-
-// WithValidationEnabled provides an option to enable the optional 'validation' state and pass a podSelector to specify
-// which pods are performing the validation
-func (m *ClusterUpgradeStateManagerImpl) WithValidationEnabled(podSelector string) ClusterUpgradeStateManager {
-	if podSelector == "" {
-		m.Log.V(consts.LogLevelWarning).Info("Cannot enable Validation state as podSelector is empty")
-		return m
-	}
-	m.ValidationManager = NewValidationManager(m.K8sInterface, m.Log, m.EventRecorder, m.NodeUpgradeStateProvider,
-		podSelector)
-	m.validationStateEnabled = true
-	return m
-}
-
-// IsPodDeletionEnabled returns true if 'pod-deletion' state is enabled
-func (m *ClusterUpgradeStateManagerImpl) IsPodDeletionEnabled() bool {
-	return m.podDeletionStateEnabled
-}
-
-// IsValidationEnabled returns true if 'validation' state is enabled
-func (m *ClusterUpgradeStateManagerImpl) IsValidationEnabled() bool {
-	return m.validationStateEnabled
-}
-
-// GetCurrentUnavailableNodes returns all nodes that are not in ready state
-// TODO: Drop ctx as it's not used
-//
-//nolint:revive
-func (m *ClusterUpgradeStateManagerImpl) GetCurrentUnavailableNodes(ctx context.Context,
-	currentState *ClusterUpgradeState) int {
-	unavailableNodes := 0
-	for _, nodeUpgradeStateList := range currentState.NodeStates {
-		for _, nodeUpgradeState := range nodeUpgradeStateList {
-			// check if the node is cordoned
-			if m.isNodeUnschedulable(nodeUpgradeState.Node) {
-				m.Log.V(consts.LogLevelDebug).Info("Node is cordoned", "node", nodeUpgradeState.Node.Name)
-				unavailableNodes++
-				continue
-			}
-			// check if the node is not ready
-			if !m.isNodeConditionReady(nodeUpgradeState.Node) {
-				m.Log.V(consts.LogLevelDebug).Info("Node is not-ready", "node", nodeUpgradeState.Node.Name)
-				unavailableNodes++
-			}
-		}
-	}
-	return unavailableNodes
+type StateOptions struct {
+	Requestor RequestorOptions
 }
 
 // BuildState builds a point-in-time snapshot of the driver upgrade state in the cluster.
@@ -217,7 +102,7 @@ func (m *ClusterUpgradeStateManagerImpl) BuildState(ctx context.Context, namespa
 
 	upgradeState := NewClusterUpgradeState()
 
-	daemonSets, err := m.getDriverDaemonSets(ctx, namespace, driverLabels)
+	daemonSets, err := m.GetDriverDaemonSets(ctx, namespace, driverLabels)
 	if err != nil {
 		m.Log.V(consts.LogLevelError).Error(err, "Failed to get driver DaemonSet list")
 		return nil, err
@@ -239,7 +124,7 @@ func (m *ClusterUpgradeStateManagerImpl) BuildState(ctx context.Context, namespa
 
 	filteredPodList := []corev1.Pod{}
 	for _, ds := range daemonSets {
-		dsPods := m.getPodsOwnedbyDs(ds, podList.Items)
+		dsPods := m.GetPodsOwnedbyDs(ds, podList.Items)
 		if int(ds.Status.DesiredNumberScheduled) != len(dsPods) {
 			m.Log.V(consts.LogLevelInfo).Info("Driver DaemonSet has Unscheduled pods", "name", ds.Name)
 			return nil, fmt.Errorf("driver DaemonSet should not have Unscheduled pods")
@@ -248,14 +133,14 @@ func (m *ClusterUpgradeStateManagerImpl) BuildState(ctx context.Context, namespa
 	}
 
 	// Collect also orphaned driver pods
-	filteredPodList = append(filteredPodList, m.getOrphanedPods(podList.Items)...)
+	filteredPodList = append(filteredPodList, m.GetOrphanedPods(podList.Items)...)
 
 	upgradeStateLabel := GetUpgradeStateLabelKey()
 
 	for i := range filteredPodList {
 		pod := &filteredPodList[i]
 		var ownerDaemonSet *appsv1.DaemonSet
-		if isOrphanedPod(pod) {
+		if IsOrphanedPod(pod) {
 			ownerDaemonSet = nil
 		} else {
 			ownerDaemonSet = daemonSets[pod.OwnerReferences[0].UID]
@@ -278,89 +163,11 @@ func (m *ClusterUpgradeStateManagerImpl) BuildState(ctx context.Context, namespa
 	return &upgradeState, nil
 }
 
-// buildNodeUpgradeState creates a mapping between a node,
-// the driver POD running on them and the daemon set, controlling this pod
-func (m *ClusterUpgradeStateManagerImpl) buildNodeUpgradeState(
-	ctx context.Context, pod *corev1.Pod, ds *appsv1.DaemonSet) (*NodeUpgradeState, error) {
-	node, err := m.NodeUpgradeStateProvider.GetNode(ctx, pod.Spec.NodeName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get node %s: %v", pod.Spec.NodeName, err)
-	}
-
-	upgradeStateLabel := GetUpgradeStateLabelKey()
-	m.Log.V(consts.LogLevelInfo).Info("Node hosting a driver pod",
-		"node", node.Name, "state", node.Labels[upgradeStateLabel])
-
-	return &NodeUpgradeState{Node: node, DriverPod: pod, DriverDaemonSet: ds}, nil
-}
-
-// getDriverDaemonSets retrieves DaemonSets with given labels and returns UID->DaemonSet map
-func (m *ClusterUpgradeStateManagerImpl) getDriverDaemonSets(ctx context.Context, namespace string,
-	labels map[string]string) (map[types.UID]*appsv1.DaemonSet, error) {
-	// Get list of driver pods
-	daemonSetList := &appsv1.DaemonSetList{}
-
-	err := m.K8sClient.List(ctx, daemonSetList,
-		client.InNamespace(namespace),
-		client.MatchingLabels(labels))
-	if err != nil {
-		return nil, fmt.Errorf("error getting DaemonSet list: %v", err)
-	}
-
-	daemonSetMap := make(map[types.UID]*appsv1.DaemonSet)
-	for i := range daemonSetList.Items {
-		daemonSet := &daemonSetList.Items[i]
-		daemonSetMap[daemonSet.UID] = daemonSet
-	}
-
-	return daemonSetMap, nil
-}
-
-// getPodsOwnedbyDs returns a list of the pods owned by the specified DaemonSet
-func (m *ClusterUpgradeStateManagerImpl) getPodsOwnedbyDs(ds *appsv1.DaemonSet, pods []corev1.Pod) []corev1.Pod {
-	dsPodList := []corev1.Pod{}
-	for i := range pods {
-		pod := &pods[i]
-		if isOrphanedPod(pod) {
-			m.Log.V(consts.LogLevelInfo).Info("Driver Pod has no owner DaemonSet", "pod", pod.Name)
-			continue
-		}
-		m.Log.V(consts.LogLevelInfo).Info("Pod", "pod", pod.Name, "owner", pod.OwnerReferences[0].Name)
-
-		if ds.UID != pod.OwnerReferences[0].UID {
-			m.Log.V(consts.LogLevelInfo).Info("Driver Pod is not owned by an Driver DaemonSet",
-				"pod", pod, "actual owner", pod.OwnerReferences[0])
-			continue
-		}
-		dsPodList = append(dsPodList, *pod)
-	}
-	return dsPodList
-}
-
-// getOrphanedPods returns a list of the pods not owned by any DaemonSet
-func (m *ClusterUpgradeStateManagerImpl) getOrphanedPods(pods []corev1.Pod) []corev1.Pod {
-	podList := []corev1.Pod{}
-	for i := range pods {
-		pod := &pods[i]
-		if isOrphanedPod(pod) {
-			podList = append(podList, *pod)
-		}
-	}
-	m.Log.V(consts.LogLevelInfo).Info("Total orphaned Pods found:", "count", len(podList))
-	return podList
-}
-
-func isOrphanedPod(pod *corev1.Pod) bool {
-	return pod.OwnerReferences == nil || len(pod.OwnerReferences) < 1
-}
-
 // ApplyState receives a complete cluster upgrade state and, based on upgrade policy, processes each node's state.
 // Based on the current state of the node, it is calculated if the node can be moved to the next state right now
 // or whether any actions need to be scheduled for the node to move to the next state.
 // The function is stateless and idempotent. If the error was returned before all nodes' states were processed,
 // ApplyState would be called again and complete the processing - all the decisions are based on the input data.
-//
-//nolint:funlen
 func (m *ClusterUpgradeStateManagerImpl) ApplyState(ctx context.Context,
 	currentState *ClusterUpgradeState, upgradePolicy *v1alpha1.DriverUpgradePolicySpec) (err error) {
 	m.Log.V(consts.LogLevelInfo).Info("State Manager, got state update")
@@ -383,32 +190,11 @@ func (m *ClusterUpgradeStateManagerImpl) ApplyState(ctx context.Context,
 		UpgradeStatePodDeletionRequired, len(currentState.NodeStates[UpgradeStatePodDeletionRequired]),
 		UpgradeStateFailed, len(currentState.NodeStates[UpgradeStateFailed]),
 		UpgradeStateDrainRequired, len(currentState.NodeStates[UpgradeStateDrainRequired]),
+		UpgradeStateNodeMaintenanceRequired, len(currentState.NodeStates[UpgradeStateNodeMaintenanceRequired]),
+		UpgradeStatePostMaintenanceRequired, len(currentState.NodeStates[UpgradeStatePostMaintenanceRequired]),
 		UpgradeStatePodRestartRequired, len(currentState.NodeStates[UpgradeStatePodRestartRequired]),
 		UpgradeStateValidationRequired, len(currentState.NodeStates[UpgradeStateValidationRequired]),
 		UpgradeStateUncordonRequired, len(currentState.NodeStates[UpgradeStateUncordonRequired]))
-
-	totalNodes := m.GetTotalManagedNodes(ctx, currentState)
-	upgradesInProgress := m.GetUpgradesInProgress(ctx, currentState)
-	currentUnavailableNodes := m.GetCurrentUnavailableNodes(ctx, currentState)
-	maxUnavailable := totalNodes
-
-	if upgradePolicy.MaxUnavailable != nil {
-		maxUnavailable, err = intstr.GetScaledValueFromIntOrPercent(upgradePolicy.MaxUnavailable, totalNodes, true)
-		if err != nil {
-			m.Log.V(consts.LogLevelError).Error(err, "Failed to compute maxUnavailable from the current total nodes")
-			return err
-		}
-	}
-
-	upgradesAvailable := m.GetUpgradesAvailable(ctx, currentState, upgradePolicy.MaxParallelUpgrades, maxUnavailable)
-
-	m.Log.V(consts.LogLevelInfo).Info("Upgrades in progress",
-		"currently in progress", upgradesInProgress,
-		"max parallel upgrades", upgradePolicy.MaxParallelUpgrades,
-		"upgrade slots available", upgradesAvailable,
-		"currently unavailable nodes", currentUnavailableNodes,
-		"total number of nodes", totalNodes,
-		"maximum nodes that can be unavailable", maxUnavailable)
 
 	// Determine the object to log this event
 	// m.EventRecorder.Eventf(m.Namespace, v1.EventTypeNormal, GetEventReason(),
@@ -427,7 +213,7 @@ func (m *ClusterUpgradeStateManagerImpl) ApplyState(ctx context.Context,
 		return err
 	}
 	// Start upgrade process for upgradesAvailable number of nodes
-	err = m.ProcessUpgradeRequiredNodes(ctx, currentState, upgradesAvailable)
+	err = m.ProcessUpgradeRequiredNodesWrapper(ctx, currentState, upgradePolicy)
 	if err != nil {
 		m.Log.V(consts.LogLevelError).Error(
 			err, "Failed to process nodes", "state", UpgradeStateUpgradeRequired)
@@ -459,11 +245,21 @@ func (m *ClusterUpgradeStateManagerImpl) ApplyState(ctx context.Context,
 		m.Log.V(consts.LogLevelError).Error(err, "Failed to schedule nodes drain")
 		return err
 	}
-	err = m.ProcessPodRestartNodes(ctx, currentState)
+
+	// TODO: in future versions we'll remove 'pod-restart-required' and use 'post-maintenance-required' instead
+	// to indicate a general post maintennace node operations (e.g. restart driver pods, node reboot etc.)
+	err = m.ProcessNodeMaintenanceRequiredNodesWrapper(ctx, currentState)
 	if err != nil {
-		m.Log.V(consts.LogLevelError).Error(err, "Failed to schedule pods restart")
+		m.Log.V(consts.LogLevelError).Error(err, "Failed for post maintenance")
 		return err
 	}
+
+	err = m.ProcessPodRestartNodes(ctx, currentState)
+	if err != nil {
+		m.Log.V(consts.LogLevelError).Error(err, "Failed for 'pod-restart-required' state")
+		return err
+	}
+
 	err = m.ProcessUpgradeFailedNodes(ctx, currentState)
 	if err != nil {
 		m.Log.V(consts.LogLevelError).Error(err, "Failed to process nodes in 'upgrade-failed' state")
@@ -474,7 +270,8 @@ func (m *ClusterUpgradeStateManagerImpl) ApplyState(ctx context.Context,
 		m.Log.V(consts.LogLevelError).Error(err, "Failed to validate driver upgrade")
 		return err
 	}
-	err = m.ProcessUncordonRequiredNodes(ctx, currentState)
+
+	err = m.ProcessUncordonRequiredNodesWrapper(ctx, currentState)
 	if err != nil {
 		m.Log.V(consts.LogLevelError).Error(err, "Failed to uncordon nodes")
 		return err
@@ -483,638 +280,99 @@ func (m *ClusterUpgradeStateManagerImpl) ApplyState(ctx context.Context,
 	return nil
 }
 
-// ProcessDoneOrUnknownNodes iterates over UpgradeStateDone or UpgradeStateUnknown nodes and determines
-// whether each specific node should be in UpgradeStateUpgradeRequired or UpgradeStateDone state.
-func (m *ClusterUpgradeStateManagerImpl) ProcessDoneOrUnknownNodes(
-	ctx context.Context, currentClusterState *ClusterUpgradeState, nodeStateName string) error {
-	m.Log.V(consts.LogLevelInfo).Info("ProcessDoneOrUnknownNodes")
-
-	for _, nodeState := range currentClusterState.NodeStates[nodeStateName] {
-		isPodSynced, isOrphaned, err := m.podInSyncWithDS(ctx, nodeState)
-		if err != nil {
-			m.Log.V(consts.LogLevelError).Error(err, "Failed to get daemonset template/pod revision hash")
-			return err
-		}
-		isUpgradeRequested := m.isUpgradeRequested(nodeState.Node)
-		isWaitingForSafeDriverLoad, err := m.SafeDriverLoadManager.IsWaitingForSafeDriverLoad(ctx, nodeState.Node)
-		if err != nil {
-			m.Log.V(consts.LogLevelError).Error(
-				err, "Failed to check safe driver load status for the node", "node", nodeState.Node.Name)
-			return err
-		}
-		if isWaitingForSafeDriverLoad {
-			m.Log.V(consts.LogLevelInfo).Info("Node is waiting for safe driver load, initialize upgrade",
-				"node", nodeState.Node.Name)
-		}
-		if (!isPodSynced && !isOrphaned) || isWaitingForSafeDriverLoad || isUpgradeRequested {
-			// If node requires upgrade and is Unschedulable, track this in an
-			// annotation and leave node in Unschedulable state when upgrade completes.
-			if isNodeUnschedulable(nodeState.Node) {
-				annotationKey := GetUpgradeInitialStateAnnotationKey()
-				annotationValue := trueString
-				m.Log.V(consts.LogLevelInfo).Info(
-					"Node is unschedulable, adding annotation to track initial state of the node",
-					"node", nodeState.Node.Name, "annotation", annotationKey)
-				err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeAnnotation(ctx, nodeState.Node, annotationKey,
-					annotationValue)
-				if err != nil {
-					return err
-				}
-			}
-			err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateUpgradeRequired)
-			if err != nil {
-				m.Log.V(consts.LogLevelError).Error(
-					err, "Failed to change node upgrade state", "state", UpgradeStateUpgradeRequired)
-				return err
-			}
-			m.Log.V(consts.LogLevelInfo).Info("Node requires upgrade, changed its state to UpgradeRequired",
-				"node", nodeState.Node.Name)
-			continue
-		}
-
-		if nodeStateName == UpgradeStateUnknown {
-			err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateDone)
-			if err != nil {
-				m.Log.V(consts.LogLevelError).Error(
-					err, "Failed to change node upgrade state", "state", UpgradeStateDone)
-				return err
-			}
-			m.Log.V(consts.LogLevelInfo).Info("Changed node state to UpgradeDone",
-				"node", nodeState.Node.Name)
-			continue
-		}
-		m.Log.V(consts.LogLevelDebug).Info("Node in UpgradeDone state, upgrade not required",
-			"node", nodeState.Node.Name)
-	}
-	return nil
+func (m *ClusterUpgradeStateManagerImpl) GetRequestor() ProcessNodeStateManager {
+	return m.requestor
 }
 
-// podInSyncWithDS check if pod is in sync with DaemonSet, handling also Orphaned Pod
-// Returns:
-//
-//	bool: True if Pod is in sync with DaemonSet. (For Orphanded Pods, always false)
-//	bool: True if the Pod is Orphaned
-//	error: In case of error retrivieng the Revision Hashes
-func (m *ClusterUpgradeStateManagerImpl) podInSyncWithDS(ctx context.Context,
-	nodeState *NodeUpgradeState) (bool, bool, error) {
-	if nodeState.IsOrphanedPod() {
-		return false, true, nil
-	}
-	podRevisionHash, err := m.PodManager.GetPodControllerRevisionHash(ctx, nodeState.DriverPod)
-	if err != nil {
-		m.Log.V(consts.LogLevelError).Error(
-			err, "Failed to get pod template revision hash", "pod", nodeState.DriverPod)
-		return false, false, err
-	}
-	m.Log.V(consts.LogLevelDebug).Info("pod template revision hash", "hash", podRevisionHash)
-	daemonsetRevisionHash, err := m.PodManager.GetDaemonsetControllerRevisionHash(ctx, nodeState.DriverDaemonSet)
-	if err != nil {
-		m.Log.V(consts.LogLevelError).Error(
-			err, "Failed to get daemonset template revision hash", "daemonset", nodeState.DriverDaemonSet)
-		return false, false, err
-	}
-	m.Log.V(consts.LogLevelDebug).Info("daemonset template revision hash", "hash", daemonsetRevisionHash)
-	return podRevisionHash == daemonsetRevisionHash, false, nil
-}
-
-// isUpgradeRequested returns true if node is labeled to request an upgrade
-func (m *ClusterUpgradeStateManagerImpl) isUpgradeRequested(node *corev1.Node) bool {
-	return node.Annotations[GetUpgradeRequestedAnnotationKey()] == "true"
-}
-
-// ProcessUpgradeRequiredNodes processes UpgradeStateUpgradeRequired nodes and moves them to UpgradeStateCordonRequired
-// until the limit on max parallel upgrades is reached.
-func (m *ClusterUpgradeStateManagerImpl) ProcessUpgradeRequiredNodes(
-	ctx context.Context, currentClusterState *ClusterUpgradeState, upgradesAvailable int) error {
-	m.Log.V(consts.LogLevelInfo).Info("ProcessUpgradeRequiredNodes")
-	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateUpgradeRequired] {
-		if m.isUpgradeRequested(nodeState.Node) {
-			// Make sure to remove the upgrade-requested annotation
-			err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeAnnotation(ctx, nodeState.Node,
-				GetUpgradeRequestedAnnotationKey(), "null")
-			if err != nil {
-				m.Log.V(consts.LogLevelError).Error(
-					err, "Failed to delete node upgrade-requested annotation")
-				return err
-			}
-		}
-		if m.skipNodeUpgrade(nodeState.Node) {
-			m.Log.V(consts.LogLevelInfo).Info("Node is marked for skipping upgrades", "node", nodeState.Node.Name)
-			continue
-		}
-
-		if upgradesAvailable <= 0 {
-			// when no new node upgrades are available, progess with manually cordoned nodes
-			if m.isNodeUnschedulable(nodeState.Node) {
-				m.Log.V(consts.LogLevelDebug).Info("Node is already cordoned, progressing for driver upgrade",
-					"node", nodeState.Node.Name)
-			} else {
-				m.Log.V(consts.LogLevelDebug).Info("Node upgrade limit reached, pausing further upgrades",
-					"node", nodeState.Node.Name)
-				continue
-			}
-		}
-
-		err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateCordonRequired)
-		if err == nil {
-			upgradesAvailable--
-			m.Log.V(consts.LogLevelInfo).Info("Node waiting for cordon",
-				"node", nodeState.Node.Name)
-		} else {
-			m.Log.V(consts.LogLevelError).Error(
-				err, "Failed to change node upgrade state", "state", UpgradeStateCordonRequired)
-			return err
-		}
-	}
-
-	return nil
-}
-
-// ProcessCordonRequiredNodes processes UpgradeStateCordonRequired nodes,
-// cordons them and moves them to UpgradeStateWaitForJobsRequired state
-func (m *ClusterUpgradeStateManagerImpl) ProcessCordonRequiredNodes(
-	ctx context.Context, currentClusterState *ClusterUpgradeState) error {
-	m.Log.V(consts.LogLevelInfo).Info("ProcessCordonRequiredNodes")
-
-	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateCordonRequired] {
-		err := m.CordonManager.Cordon(ctx, nodeState.Node)
-		if err != nil {
-			m.Log.V(consts.LogLevelWarning).Error(
-				err, "Node cordon failed", "node", nodeState.Node)
-			return err
-		}
-		err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateWaitForJobsRequired)
-		if err != nil {
-			m.Log.V(consts.LogLevelError).Error(
-				err, "Failed to change node upgrade state", "state", UpgradeStateWaitForJobsRequired)
-			return err
-		}
-	}
-	return nil
-}
-
-// ProcessWaitForJobsRequiredNodes processes UpgradeStateWaitForJobsRequired nodes,
-// waits for completion of jobs and moves them to UpgradeStatePodDeletionRequired state.
-func (m *ClusterUpgradeStateManagerImpl) ProcessWaitForJobsRequiredNodes(
-	ctx context.Context, currentClusterState *ClusterUpgradeState,
-	waitForCompletionSpec *v1alpha1.WaitForCompletionSpec) error {
-	m.Log.V(consts.LogLevelInfo).Info("ProcessWaitForJobsRequiredNodes")
-
-	nodes := make([]*corev1.Node, 0, len(currentClusterState.NodeStates[UpgradeStateWaitForJobsRequired]))
-	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateWaitForJobsRequired] {
-		nodes = append(nodes, nodeState.Node)
-		if waitForCompletionSpec == nil || waitForCompletionSpec.PodSelector == "" {
-			// update node state to next state as no pod selector is specified for waiting
-			m.Log.V(consts.LogLevelInfo).Info("No jobs to wait for as no pod selector was provided. Moving to next state.")
-			nextState := UpgradeStatePodDeletionRequired
-			if !m.IsPodDeletionEnabled() {
-				nextState = UpgradeStateDrainRequired
-			}
-			_ = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, nextState)
-			m.Log.V(consts.LogLevelInfo).Info("Updated the node state", "node", nodeState.Node.Name, "state", nextState)
-		}
-	}
-	// return if no pod selector is provided for waiting
-	if waitForCompletionSpec == nil || waitForCompletionSpec.PodSelector == "" {
-		return nil
-	}
-
-	if len(nodes) == 0 {
-		// no nodes to process in this state
-		return nil
-	}
-
-	podManagerConfig := PodManagerConfig{WaitForCompletionSpec: waitForCompletionSpec, Nodes: nodes}
-	err := m.PodManager.ScheduleCheckOnPodCompletion(ctx, &podManagerConfig)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// ProcessPodDeletionRequiredNodes processes UpgradeStatePodDeletionRequired nodes,
-// deletes select pods on a node, and moves the nodes to UpgradeStateDrainRequiredRequired state.
-// Pods selected for deletion are determined via PodManager.PodDeletion
-func (m *ClusterUpgradeStateManagerImpl) ProcessPodDeletionRequiredNodes(
-	ctx context.Context, currentClusterState *ClusterUpgradeState, podDeletionSpec *v1alpha1.PodDeletionSpec,
-	drainEnabled bool) error {
-	m.Log.V(consts.LogLevelInfo).Info("ProcessPodDeletionRequiredNodes")
-
-	if !m.IsPodDeletionEnabled() {
-		m.Log.V(consts.LogLevelInfo).Info("PodDeletion is not enabled, proceeding straight to the next state")
-		for _, nodeState := range currentClusterState.NodeStates[UpgradeStatePodDeletionRequired] {
-			_ = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateDrainRequired)
-		}
-		return nil
-	}
-
-	podManagerConfig := PodManagerConfig{
-		DeletionSpec: podDeletionSpec,
-		DrainEnabled: drainEnabled,
-		Nodes:        make([]*corev1.Node, 0, len(currentClusterState.NodeStates[UpgradeStatePodDeletionRequired])),
-	}
-
-	for _, nodeState := range currentClusterState.NodeStates[UpgradeStatePodDeletionRequired] {
-		podManagerConfig.Nodes = append(podManagerConfig.Nodes, nodeState.Node)
-	}
-
-	if len(podManagerConfig.Nodes) == 0 {
-		// no nodes to process in this state
-		return nil
-	}
-
-	return m.PodManager.SchedulePodEviction(ctx, &podManagerConfig)
-}
-
-// ProcessDrainNodes schedules UpgradeStateDrainRequired nodes for drain.
-// If drain is disabled by upgrade policy, moves the nodes straight to UpgradeStatePodRestartRequired state.
-func (m *ClusterUpgradeStateManagerImpl) ProcessDrainNodes(
-	ctx context.Context, currentClusterState *ClusterUpgradeState, drainSpec *v1alpha1.DrainSpec) error {
-	m.Log.V(consts.LogLevelInfo).Info("ProcessDrainNodes")
-	if drainSpec == nil || !drainSpec.Enable {
-		// If node drain is disabled, move nodes straight to PodRestart stage
-		m.Log.V(consts.LogLevelInfo).Info("Node drain is disabled by policy, skipping this step")
-		for _, nodeState := range currentClusterState.NodeStates[UpgradeStateDrainRequired] {
-			err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node,
-				UpgradeStatePodRestartRequired)
-			if err != nil {
-				m.Log.V(consts.LogLevelError).Error(
-					err, "Failed to change node upgrade state", "state", UpgradeStatePodRestartRequired)
-				return err
-			}
-		}
-		return nil
-	}
-
-	drainConfig := DrainConfiguration{
-		Spec:  drainSpec,
-		Nodes: make([]*corev1.Node, 0, len(currentClusterState.NodeStates[UpgradeStateDrainRequired])),
-	}
-	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateDrainRequired] {
-		drainConfig.Nodes = append(drainConfig.Nodes, nodeState.Node)
-	}
-
-	m.Log.V(consts.LogLevelInfo).Info("Scheduling nodes drain", "drainConfig", drainConfig)
-
-	return m.DrainManager.ScheduleNodesDrain(ctx, &drainConfig)
-}
-
-// ProcessPodRestartNodes processes UpgradeStatePodRestartRequirednodes and schedules driver pod restart for them.
-// If the pod has already been restarted and is in Ready state - moves the node to UpgradeStateUncordonRequired state.
-func (m *ClusterUpgradeStateManagerImpl) ProcessPodRestartNodes(
-	ctx context.Context, currentClusterState *ClusterUpgradeState) error {
-	m.Log.V(consts.LogLevelInfo).Info("ProcessPodRestartNodes")
-
-	pods := make([]*corev1.Pod, 0, len(currentClusterState.NodeStates[UpgradeStatePodRestartRequired]))
-	for _, nodeState := range currentClusterState.NodeStates[UpgradeStatePodRestartRequired] {
-		isPodSynced, isOrphaned, err := m.podInSyncWithDS(ctx, nodeState)
-		if err != nil {
-			m.Log.V(consts.LogLevelError).Error(err, "Failed to get daemonset template/pod revision hash")
-			return err
-		}
-		if !isPodSynced || isOrphaned {
-			// Pods should only be scheduled for restart if they are not terminating or restarting already
-			// To determinate terminating state we need to check for deletion timestamp with will be filled
-			// one pod termination process started
-			if nodeState.DriverPod.ObjectMeta.DeletionTimestamp.IsZero() {
-				pods = append(pods, nodeState.DriverPod)
-			}
-		} else {
-			err := m.SafeDriverLoadManager.UnblockLoading(ctx, nodeState.Node)
-			if err != nil {
-				m.Log.V(consts.LogLevelError).Error(
-					err, "Failed to unblock loading of the driver", "nodeState", nodeState)
-				return err
-			}
-			driverPodInSync, err := m.isDriverPodInSync(ctx, nodeState)
-			if err != nil {
-				m.Log.V(consts.LogLevelError).Error(
-					err, "Failed to check if driver pod on the node is in sync", "nodeState", nodeState)
-				return err
-			}
-			if driverPodInSync {
-				if !m.IsValidationEnabled() {
-					err = m.updateNodeToUncordonOrDoneState(ctx, nodeState.Node)
-					if err != nil {
-						return err
-					}
-					continue
-				}
-
-				err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node,
-					UpgradeStateValidationRequired)
-				if err != nil {
-					m.Log.V(consts.LogLevelError).Error(
-						err, "Failed to change node upgrade state", "state", UpgradeStateValidationRequired)
-					return err
-				}
-			} else {
-				// driver pod not in sync, move node to failed state if repeated container restarts
-				if !m.isDriverPodFailing(nodeState.DriverPod) {
-					continue
-				}
-				m.Log.V(consts.LogLevelInfo).Info("Driver pod is failing on node with repeated restarts",
-					"node", nodeState.Node.Name, "pod", nodeState.DriverPod.Name)
-				err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateFailed)
-				if err != nil {
-					m.Log.V(consts.LogLevelError).Error(
-						err, "Failed to change node upgrade state for node", "node", nodeState.Node.Name,
-						"state", UpgradeStateFailed)
-					return err
-				}
-			}
-		}
-	}
-
-	// Create pod restart manager to handle pod restarts
-	return m.PodManager.SchedulePodsRestart(ctx, pods)
-}
-
-// ProcessUpgradeFailedNodes processes UpgradeStateFailed nodes and checks whether the driver pod on the node
-// has been successfully restarted. If the pod is in Ready state - moves the node to UpgradeStateUncordonRequired state.
-func (m *ClusterUpgradeStateManagerImpl) ProcessUpgradeFailedNodes(
-	ctx context.Context, currentClusterState *ClusterUpgradeState) error {
-	m.Log.V(consts.LogLevelInfo).Info("ProcessUpgradeFailedNodes")
-
-	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateFailed] {
-		driverPodInSync, err := m.isDriverPodInSync(ctx, nodeState)
-		if err != nil {
-			m.Log.V(consts.LogLevelError).Error(
-				err, "Failed to check if driver pod on the node is in sync", "nodeState", nodeState)
-			return err
-		}
-		if driverPodInSync {
-			newUpgradeState := UpgradeStateUncordonRequired
-			// If node was Unschedulable at beginning of upgrade, skip the
-			// uncordon state so that node remains in the same state as
-			// when the upgrade started.
-			annotationKey := GetUpgradeInitialStateAnnotationKey()
-			if _, ok := nodeState.Node.Annotations[annotationKey]; ok {
-				m.Log.V(consts.LogLevelInfo).Info("Node was Unschedulable at beginning of upgrade, skipping uncordon",
-					"node", nodeState.Node.Name)
-				newUpgradeState = UpgradeStateDone
-			}
-
-			err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, newUpgradeState)
-			if err != nil {
-				m.Log.V(consts.LogLevelError).Error(
-					err, "Failed to change node upgrade state", "state", newUpgradeState)
-				return err
-			}
-
-			if newUpgradeState == UpgradeStateDone {
-				m.Log.V(consts.LogLevelDebug).Info("Removing node upgrade annotation",
-					"node", nodeState.Node.Name, "annotation", annotationKey)
-				err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeAnnotation(ctx, nodeState.Node, annotationKey, "null")
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-// ProcessValidationRequiredNodes processes UpgradeStateValidationRequired nodes
-func (m *ClusterUpgradeStateManagerImpl) ProcessValidationRequiredNodes(
-	ctx context.Context, currentClusterState *ClusterUpgradeState) error {
-	m.Log.V(consts.LogLevelInfo).Info("ProcessValidationRequiredNodes")
-
-	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateValidationRequired] {
-		node := nodeState.Node
-		// make sure that the driver Pod is not waiting for the safe load,
-		// this may happen in case if driver restarted after it was moved to UpgradeStateValidationRequired state
-		err := m.SafeDriverLoadManager.UnblockLoading(ctx, nodeState.Node)
-		if err != nil {
-			m.Log.V(consts.LogLevelError).Error(
-				err, "Failed to unblock loading of the driver", "nodeState", nodeState)
-			return err
-		}
-		validationDone, err := m.ValidationManager.Validate(ctx, node)
-		if err != nil {
-			m.Log.V(consts.LogLevelError).Error(err, "Failed to validate driver upgrade", "node", node.Name)
-			return err
-		}
-
-		if !validationDone {
-			m.Log.V(consts.LogLevelInfo).Info("Validations not complete on the node", "node", node.Name)
-			continue
-		}
-
-		err = m.updateNodeToUncordonOrDoneState(ctx, node)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// ProcessUncordonRequiredNodes processes UpgradeStateUncordonRequired nodes,
-// uncordons them and moves them to UpgradeStateDone state
-func (m *ClusterUpgradeStateManagerImpl) ProcessUncordonRequiredNodes(
-	ctx context.Context, currentClusterState *ClusterUpgradeState) error {
-	m.Log.V(consts.LogLevelInfo).Info("ProcessUncordonRequiredNodes")
-
-	for _, nodeState := range currentClusterState.NodeStates[UpgradeStateUncordonRequired] {
-		err := m.CordonManager.Uncordon(ctx, nodeState.Node)
-		if err != nil {
-			m.Log.V(consts.LogLevelWarning).Error(
-				err, "Node uncordon failed", "node", nodeState.Node)
-			return err
-		}
-		err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, nodeState.Node, UpgradeStateDone)
-		if err != nil {
-			m.Log.V(consts.LogLevelError).Error(
-				err, "Failed to change node upgrade state", "state", UpgradeStateDone)
-			return err
-		}
-	}
-	return nil
-}
-
-func (m *ClusterUpgradeStateManagerImpl) isDriverPodInSync(ctx context.Context,
-	nodeState *NodeUpgradeState) (bool, error) {
-	isPodSynced, isOrphaned, err := m.podInSyncWithDS(ctx, nodeState)
-	if err != nil {
-		m.Log.V(consts.LogLevelError).Error(err, "Failed to get daemonset template/pod revision hash")
-		return false, err
-	}
-	if isOrphaned {
-		return false, nil
-	}
-	// If the pod generation matches the daemonset generation
-	if isPodSynced &&
-		// And the pod is running
-		nodeState.DriverPod.Status.Phase == corev1.PodRunning &&
-		// And it has at least 1 container
-		len(nodeState.DriverPod.Status.ContainerStatuses) != 0 {
-		for i := range nodeState.DriverPod.Status.ContainerStatuses {
-			if !nodeState.DriverPod.Status.ContainerStatuses[i].Ready {
-				// Return false if at least 1 container isn't ready
-				return false, nil
-			}
-		}
-
-		// And each container is ready
-		return true, nil
-	}
-
-	return false, nil
-}
-
-func (m *ClusterUpgradeStateManagerImpl) isDriverPodFailing(pod *corev1.Pod) bool {
-	for _, status := range pod.Status.InitContainerStatuses {
-		if !status.Ready && status.RestartCount > 10 {
-			return true
-		}
-	}
-	for _, status := range pod.Status.ContainerStatuses {
-		if !status.Ready && status.RestartCount > 10 {
-			return true
-		}
-	}
-	return false
-}
-
-// isNodeUnschedulable returns true if the node is cordoned
-func (m *ClusterUpgradeStateManagerImpl) isNodeUnschedulable(node *corev1.Node) bool {
-	return node.Spec.Unschedulable
-}
-
-// isNodeConditionReady returns true if the node condition is ready
-func (m *ClusterUpgradeStateManagerImpl) isNodeConditionReady(node *corev1.Node) bool {
-	for _, condition := range node.Status.Conditions {
-		if condition.Type == corev1.NodeReady && condition.Status != corev1.ConditionTrue {
-			return false
-		}
-	}
-	return true
-}
-
-// skipNodeUpgrade returns true if node is labeled to skip driver upgrades
-func (m *ClusterUpgradeStateManagerImpl) skipNodeUpgrade(node *corev1.Node) bool {
-	return node.Labels[GetUpgradeSkipNodeLabelKey()] == trueString
-}
-
-// updateNodeToUncordonOrDoneState skips moving the node to the UncordonRequired state if the node
-// was Unschedulable at the beginning of the upgrade so that the node remains in the same state as
-// when the upgrade started. In addition, the annotation tracking this information is removed.
-func (m *ClusterUpgradeStateManagerImpl) updateNodeToUncordonOrDoneState(ctx context.Context, node *corev1.Node) error {
-	newUpgradeState := UpgradeStateUncordonRequired
-	annotationKey := GetUpgradeInitialStateAnnotationKey()
-	if _, ok := node.Annotations[annotationKey]; ok {
-		m.Log.V(consts.LogLevelInfo).Info("Node was Unschedulable at beginning of upgrade, skipping uncordon",
-			"node", node.Name)
-		newUpgradeState = UpgradeStateDone
-	}
-
-	err := m.NodeUpgradeStateProvider.ChangeNodeUpgradeState(ctx, node, newUpgradeState)
-	if err != nil {
-		m.Log.V(consts.LogLevelError).Error(
-			err, "Failed to change node upgrade state", "node", node.Name, "state", newUpgradeState)
-		return err
-	}
-
-	if newUpgradeState == UpgradeStateDone {
-		m.Log.V(consts.LogLevelDebug).Info("Removing node upgrade annotation",
-			"node", node.Name, "annotation", annotationKey)
-		err = m.NodeUpgradeStateProvider.ChangeNodeUpgradeAnnotation(ctx, node, annotationKey, "null")
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func isNodeUnschedulable(node *corev1.Node) bool {
-	return node.Spec.Unschedulable
-}
-
-// GetTotalManagedNodes returns the total count of nodes managed for driver upgrades
-// TODO: Drop ctx as it's not used
-//
-//nolint:revive
-func (m *ClusterUpgradeStateManagerImpl) GetTotalManagedNodes(ctx context.Context,
-	currentState *ClusterUpgradeState) int {
-	totalNodes := len(currentState.NodeStates[UpgradeStateUnknown]) +
-		len(currentState.NodeStates[UpgradeStateDone]) +
-		len(currentState.NodeStates[UpgradeStateUpgradeRequired]) +
-		len(currentState.NodeStates[UpgradeStateCordonRequired]) +
-		len(currentState.NodeStates[UpgradeStateWaitForJobsRequired]) +
-		len(currentState.NodeStates[UpgradeStatePodDeletionRequired]) +
-		len(currentState.NodeStates[UpgradeStateFailed]) +
-		len(currentState.NodeStates[UpgradeStateDrainRequired]) +
-		len(currentState.NodeStates[UpgradeStatePodRestartRequired]) +
-		len(currentState.NodeStates[UpgradeStateUncordonRequired]) +
-		len(currentState.NodeStates[UpgradeStateValidationRequired])
-
-	return totalNodes
-}
-
-// GetUpgradesInProgress returns count of nodes on which upgrade is in progress
-func (m *ClusterUpgradeStateManagerImpl) GetUpgradesInProgress(ctx context.Context,
-	currentState *ClusterUpgradeState) int {
-	totalNodes := m.GetTotalManagedNodes(ctx, currentState)
-	return totalNodes - (len(currentState.NodeStates[UpgradeStateUnknown]) +
-		len(currentState.NodeStates[UpgradeStateDone]) +
-		len(currentState.NodeStates[UpgradeStateUpgradeRequired]))
-}
-
-// GetUpgradesDone returns count of nodes on which upgrade is complete
-// TODO: Drop ctx as it's not used
-//
-//nolint:revive
-func (m *ClusterUpgradeStateManagerImpl) GetUpgradesDone(ctx context.Context,
-	currentState *ClusterUpgradeState) int {
-	return len(currentState.NodeStates[UpgradeStateDone])
-}
-
-// GetUpgradesAvailable returns count of nodes on which upgrade can be done
-func (m *ClusterUpgradeStateManagerImpl) GetUpgradesAvailable(ctx context.Context,
-	currentState *ClusterUpgradeState, maxParallelUpgrades int, maxUnavailable int) int {
-	upgradesInProgress := m.GetUpgradesInProgress(ctx, currentState)
-	totalNodes := m.GetTotalManagedNodes(ctx, currentState)
-
-	var upgradesAvailable int
-	if maxParallelUpgrades == 0 {
-		// Only nodes in UpgradeStateUpgradeRequired can start upgrading, so all of them will move to drain stage
-		upgradesAvailable = len(currentState.NodeStates[UpgradeStateUpgradeRequired])
+func (m *ClusterUpgradeStateManagerImpl) ProcessUpgradeRequiredNodesWrapper(ctx context.Context,
+	currentState *ClusterUpgradeState, upgradePolicy *v1alpha1.DriverUpgradePolicySpec) error {
+	var err error
+	// Start upgrade process for upgradesAvailable number of nodes
+	if m.opts.Requestor.UseMaintenanceOperator {
+		err = m.requestor.ProcessUpgradeRequiredNodes(ctx, currentState, upgradePolicy)
 	} else {
-		upgradesAvailable = maxParallelUpgrades - upgradesInProgress
+		err = m.inplace.ProcessUpgradeRequiredNodes(ctx, currentState, upgradePolicy)
 	}
-
-	// Apply the maxUnavailable constraint based on the number of nodes unavailable in the cluster
-	// Get nodes in cordoned/not-ready state and also include nodes that are about to be cordoned.
-	currentUnavailableNodes := m.GetCurrentUnavailableNodes(ctx, currentState) +
-		len(currentState.NodeStates[UpgradeStateCordonRequired])
-	// always limit upgradesAvailalbe to maxUnavailable
-	if upgradesAvailable > maxUnavailable {
-		upgradesAvailable = maxUnavailable
-	}
-	// apply additional limits when there are already unavailable nodes
-	if currentUnavailableNodes >= maxUnavailable {
-		upgradesAvailable = 0
-	} else if maxUnavailable < totalNodes && currentUnavailableNodes+upgradesAvailable > maxUnavailable {
-		upgradesAvailable = maxUnavailable - currentUnavailableNodes
-	}
-	return upgradesAvailable
+	return err
 }
 
-// GetUpgradesFailed returns count of nodes on which upgrades have failed
-// TODO: Drop ctx as it's not used
-//
-//nolint:revive
-func (m *ClusterUpgradeStateManagerImpl) GetUpgradesFailed(ctx context.Context,
-	currentState *ClusterUpgradeState) int {
-	return len(currentState.NodeStates[UpgradeStateFailed])
+func (m *ClusterUpgradeStateManagerImpl) ProcessNodeMaintenanceRequiredNodesWrapper(ctx context.Context,
+	currentState *ClusterUpgradeState) error {
+	var err error
+	if m.opts.Requestor.UseMaintenanceOperator {
+		if err = m.requestor.ProcessNodeMaintenanceRequiredNodes(ctx, currentState); err != nil {
+			return err
+		}
+	}
+
+	return err
 }
 
-// GetUpgradesPending returns count of nodes on which are marked for upgrades and upgrade is pending
-// TODO: Drop ctx as it's not used
-//
-//nolint:revive
-func (m *ClusterUpgradeStateManagerImpl) GetUpgradesPending(ctx context.Context,
-	currentState *ClusterUpgradeState) int {
-	return len(currentState.NodeStates[UpgradeStateUpgradeRequired])
+func (m *ClusterUpgradeStateManagerImpl) ProcessUncordonRequiredNodesWrapper(ctx context.Context,
+	currentState *ClusterUpgradeState) error {
+	// The idea of calling both inplace and requestor ProcessUncordonRequiredNodes is to handle a case
+	// where some nodes had already undergone inplace upgrage process, and yet to complete it,
+	// before enabling requestor upgrade mode. In this case, although requestor upgrade mode is enabled,
+	// inplace flow will keep processing pending nodes which already started inplace upgrade process.
+	err := m.inplace.ProcessUncordonRequiredNodes(ctx, currentState)
+	if err != nil {
+		return err
+	}
+	if m.opts.Requestor.UseMaintenanceOperator {
+		err = m.requestor.ProcessUncordonRequiredNodes(ctx, currentState)
+	}
+	return err
+}
+
+// WithPodDeletionEnabled provides an option to enable the optional 'pod-deletion' state and pass a custom
+// PodDeletionFilter to use
+func (m *ClusterUpgradeStateManagerImpl) WithPodDeletionEnabled(filter PodDeletionFilter) ClusterUpgradeStateManager {
+	if filter == nil {
+		m.Log.V(consts.LogLevelWarning).Info("Cannot enable PodDeletion state as PodDeletionFilter is nil")
+		return m
+	}
+	m.PodManager = NewPodManager(m.K8sInterface, m.NodeUpgradeStateProvider, m.Log, filter, m.EventRecorder)
+	m.podDeletionStateEnabled = true
+	return m
+}
+
+// WithValidationEnabled provides an option to enable the optional 'validation' state and pass a podSelector to specify
+// which pods are performing the validation
+func (m *ClusterUpgradeStateManagerImpl) WithValidationEnabled(podSelector string) ClusterUpgradeStateManager {
+	if podSelector == "" {
+		m.Log.V(consts.LogLevelWarning).Info("Cannot enable Validation state as podSelector is empty")
+		return m
+	}
+	m.ValidationManager = NewValidationManager(m.K8sInterface, m.Log, m.EventRecorder, m.NodeUpgradeStateProvider,
+		podSelector)
+	m.validationStateEnabled = true
+	return m
+}
+
+// buildNodeUpgradeState creates a mapping between a node,
+// the driver POD running on them and the daemon set, controlling this pod
+func (m *ClusterUpgradeStateManagerImpl) buildNodeUpgradeState(
+	ctx context.Context, pod *corev1.Pod, ds *appsv1.DaemonSet) (*NodeUpgradeState, error) {
+	var nm client.Object
+	node, err := m.NodeUpgradeStateProvider.GetNode(ctx, pod.Spec.NodeName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get node %s: %v", pod.Spec.NodeName, err)
+	}
+
+	if m.opts.Requestor.UseMaintenanceOperator {
+		rum, ok := m.requestor.(*RequestorNodeStateManagerImpl)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast rquestor upgrade manager: %v", err)
+		}
+		nm, err = rum.GetNodeMaintenanceObj(ctx, node.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed while trying to fetch nodeMaintennace obj: %v", err)
+		}
+	}
+
+	upgradeStateLabel := GetUpgradeStateLabelKey()
+	m.Log.V(consts.LogLevelInfo).Info("Node hosting a driver pod",
+		"node", node.Name, "state", node.Labels[upgradeStateLabel])
+
+	return &NodeUpgradeState{Node: node, DriverPod: pod, DriverDaemonSet: ds, NodeMaintenance: nm}, nil
 }

--- a/pkg/upgrade/upgrade_state_test.go
+++ b/pkg/upgrade/upgrade_state_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,31 +31,81 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	maintenancev1alpha1 "github.com/Mellanox/maintenance-operator/api/v1alpha1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	v1alpha1 "github.com/NVIDIA/k8s-operator-libs/api/upgrade/v1alpha1"
-	"github.com/NVIDIA/k8s-operator-libs/pkg/upgrade"
+	upgrade "github.com/NVIDIA/k8s-operator-libs/pkg/upgrade"
 	"github.com/NVIDIA/k8s-operator-libs/pkg/upgrade/mocks"
 )
 
+var (
+	stateManager          *upgrade.ClusterUpgradeStateManagerImpl
+	stateManagerInterface upgrade.ClusterUpgradeStateManager
+	opts                  upgrade.StateOptions
+)
+
 var _ = Describe("UpgradeStateManager tests", func() {
-	var ctx context.Context
 	var id string
-	var stateManager *upgrade.ClusterUpgradeStateManagerImpl
 
 	BeforeEach(func() {
-		ctx = context.TODO()
-		id = randSeq(5)
-		// Create new ClusterUpgradeStateManagerImpl using mocked managers initialized in BeforeSuite()
 		var err error
-		stateManagerInterface, err := upgrade.NewClusterUpgradeStateManager(log, k8sConfig, eventRecorder)
+		id = randSeq(5)
+		opts := upgrade.StateOptions{}
+		// Create new ClusterUpgradeStateManagerImpl using mocked managers initialized in BeforeSuite()
+		stateManagerInterface, err = upgrade.NewClusterUpgradeStateManager(log, k8sConfig,
+			eventRecorder, opts)
 		Expect(err).NotTo(HaveOccurred())
+
 		stateManager, _ = stateManagerInterface.(*upgrade.ClusterUpgradeStateManagerImpl)
 		stateManager.NodeUpgradeStateProvider = &nodeUpgradeStateProvider
 		stateManager.DrainManager = &drainManager
 		stateManager.CordonManager = &cordonManager
 		stateManager.PodManager = &podManager
 		stateManager.ValidationManager = &validationManager
+	})
 
+	AfterEach(func() {
+		By("Cleanup NodeMaintenance resources")
+		Eventually(func() bool {
+			nodes := &corev1.NodeList{}
+			err := k8sClient.List(testCtx, nodes)
+			if err != nil && k8serrors.IsNotFound(err) {
+				return true
+			}
+			Expect(err).NotTo(HaveOccurred())
+			if len(nodes.Items) == 0 {
+				return true
+			}
+			Expect(err).NotTo(HaveOccurred())
+			for _, item := range nodes.Items {
+				err = k8sClient.Delete(testCtx, &item)
+				if err != nil && k8serrors.IsNotFound(err) {
+					err = nil
+				}
+				Expect(err).NotTo(HaveOccurred())
+			}
+			return false
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(BeTrue())
+
+		Eventually(func() bool {
+			nms := &maintenancev1alpha1.NodeMaintenanceList{}
+			err := k8sClient.List(testCtx, nms)
+			if err != nil && k8serrors.IsNotFound(err) {
+				return true
+			}
+			Expect(err).NotTo(HaveOccurred())
+			if len(nms.Items) == 0 {
+				return true
+			}
+			for _, item := range nms.Items {
+				err = removeFinalizersOrDelete(testCtx, &item)
+				Expect(err).NotTo(HaveOccurred())
+			}
+			return false
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(BeTrue())
 	})
 
 	Describe("BuildState", func() {
@@ -64,7 +116,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 		})
 
 		It("should not fail when no pods exist", func() {
-			upgradeState, err := stateManager.BuildState(ctx, namespace.Name, map[string]string{"foo": "bar"})
+			upgradeState, err := stateManagerInterface.BuildState(testCtx, namespace.Name, map[string]string{"foo": "bar"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(upgradeState.NodeStates)).To(Equal(0))
 		})
@@ -86,7 +138,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				}).
 				Create()
 
-			upgradeState, err := stateManager.BuildState(ctx, namespace.Name, selector)
+			upgradeState, err := stateManagerInterface.BuildState(testCtx, namespace.Name, selector)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(upgradeState.NodeStates)).To(Equal(1))
 		})
@@ -110,7 +162,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			err := updatePodStatus(pod)
 			Expect(err).To(Succeed())
 
-			upgradeState, err := stateManager.BuildState(ctx, namespace.Name, selector)
+			upgradeState, err := stateManagerInterface.BuildState(testCtx, namespace.Name, selector)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(upgradeState.NodeStates)).To(Equal(0))
 		})
@@ -122,7 +174,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				WithLabels(selector).
 				Create()
 
-			upgradeState, err := stateManager.BuildState(ctx, namespace.Name, selector)
+			upgradeState, err := stateManagerInterface.BuildState(testCtx, namespace.Name, selector)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(upgradeState.NodeStates)).To(Equal(1))
 			Expect(upgradeState.NodeStates[""][0].IsOrphanedPod()).To(BeTrue())
@@ -130,11 +182,12 @@ var _ = Describe("UpgradeStateManager tests", func() {
 	})
 
 	Describe("ApplyState", func() {
+
 		It("UpgradeStateManager should fail on nil currentState", func() {
-			Expect(stateManager.ApplyState(ctx, nil, &v1alpha1.DriverUpgradePolicySpec{})).ToNot(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, nil, &v1alpha1.DriverUpgradePolicySpec{})).ToNot(Succeed())
 		})
 		It("UpgradeStateManager should not fail on nil upgradePolicy", func() {
-			Expect(stateManager.ApplyState(ctx, &upgrade.ClusterUpgradeState{}, nil)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &upgrade.ClusterUpgradeState{}, nil)).To(Succeed())
 		})
 		It("UpgradeStateManager should move up-to-date nodes to Done and outdated nodes to UpgradeRequired states", func() {
 			daemonSet := &appsv1.DaemonSet{ObjectMeta: v1.ObjectMeta{}}
@@ -160,14 +213,14 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			clusterState.NodeStates[""] = unknownNodes
 			clusterState.NodeStates[upgrade.UpgradeStateDone] = doneNodes
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
 			Expect(getNodeUpgradeState(UnknownToDoneNode)).To(Equal(upgrade.UpgradeStateDone))
 			Expect(getNodeUpgradeState(UnknownToUpgradeRequiredNode)).To(Equal(upgrade.UpgradeStateUpgradeRequired))
 			Expect(getNodeUpgradeState(DoneToDoneNode)).To(Equal(upgrade.UpgradeStateDone))
 			Expect(getNodeUpgradeState(DoneToUpgradeRequiredNode)).To(Equal(upgrade.UpgradeStateUpgradeRequired))
 		})
 		It("UpgradeStateManager should move outdated nodes to UpgradeRequired state and annotate node if unschedulable", func() {
-			ctx := context.TODO()
+			testCtx := context.TODO()
 
 			daemonSet := &appsv1.DaemonSet{ObjectMeta: v1.ObjectMeta{}}
 			upToDatePod := &corev1.Pod{
@@ -195,7 +248,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
 			stateManager.NodeUpgradeStateProvider = provider
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
 			Expect(getNodeUpgradeState(UnknownToDoneNode)).To(Equal(upgrade.UpgradeStateDone))
 			Expect(getNodeUpgradeState(UnknownToUpgradeRequiredNode)).To(Equal(upgrade.UpgradeStateUpgradeRequired))
 			Expect(getNodeUpgradeState(DoneToDoneNode)).To(Equal(upgrade.UpgradeStateDone))
@@ -213,7 +266,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 		})
 		It("UpgradeStateManager should move up-to-date nodes with safe driver loading annotation "+
 			"to UpgradeRequired state", func() {
-			ctx := context.TODO()
+			testCtx := context.TODO()
 
 			safeLoadAnnotationKey := upgrade.GetUpgradeDriverWaitForSafeLoadAnnotationKey()
 			daemonSet := &appsv1.DaemonSet{ObjectMeta: v1.ObjectMeta{}}
@@ -231,7 +284,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
 			stateManager.NodeUpgradeStateProvider = provider
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
 			Expect(getNodeUpgradeState(waitForSafeLoadNode)).To(Equal(upgrade.UpgradeStateUpgradeRequired))
 		})
 		It("UpgradeStateManager should schedule upgrade on all nodes if maxParallel upgrades is set to 0", func() {
@@ -252,7 +305,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				MaxParallelUpgrades: 0,
 			}
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			stateCount := make(map[string]int)
 			for i := range nodeStates {
 				state := getNodeUpgradeState(clusterState.NodeStates[upgrade.UpgradeStateUpgradeRequired][i].Node)
@@ -281,7 +334,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				MaxParallelUpgrades: maxParallelUpgrades,
 			}
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			stateCount := make(map[string]int)
 			for i := range nodeStates {
 				state := getNodeUpgradeState(nodeStates[i].Node)
@@ -314,7 +367,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				},
 			}
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			stateCount := make(map[string]int)
 			for _, state := range append(upgradeRequiredNodes, cordonRequiredNodes...) {
 				state := getNodeUpgradeState(state.Node)
@@ -344,7 +397,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "100%"},
 			}
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			stateCount := make(map[string]int)
 			for i := range nodeStates {
 				state := getNodeUpgradeState(clusterState.NodeStates[upgrade.UpgradeStateUpgradeRequired][i].Node)
@@ -372,7 +425,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				MaxUnavailable:      &intstr.IntOrString{Type: intstr.String, StrVal: "50%"},
 			}
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			stateCount := make(map[string]int)
 			for i := range nodeStates {
 				state := getNodeUpgradeState(clusterState.NodeStates[upgrade.UpgradeStateUpgradeRequired][i].Node)
@@ -418,17 +471,17 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			podManagerMock := mocks.PodManager{}
 			podManagerMock.
 				On("SchedulePodsRestart", mock.Anything, mock.Anything).
-				Return(func(ctx context.Context, podsToDelete []*corev1.Pod) error {
+				Return(func(testCtx context.Context, podsToDelete []*corev1.Pod) error {
 					Expect(podsToDelete).To(HaveLen(0))
 					return nil
 				})
 			podManagerMock.
-				On("GetPodControllerRevisionHash", mock.Anything, mock.Anything).
+				On("GetPodControllerRevisionHash", mock.Anything).
 				Return(
-					func(ctx context.Context, pod *corev1.Pod) string {
+					func(pod *corev1.Pod) string {
 						return pod.Labels[upgrade.PodControllerRevisionHashLabelKey]
 					},
-					func(ctx context.Context, pod *corev1.Pod) error {
+					func(pod *corev1.Pod) error {
 						return nil
 					},
 				)
@@ -437,7 +490,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				Return("test-hash-12345", nil)
 			stateManager.PodManager = &podManagerMock
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			stateCount := make(map[string]int)
 			for i := range upgradeRequiredNodes {
 				state := getNodeUpgradeState(clusterState.NodeStates[upgrade.UpgradeStateUpgradeRequired][i].Node)
@@ -475,7 +528,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				MaxUnavailable:      &intstr.IntOrString{Type: intstr.Int, IntVal: 2},
 			}
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			stateCount := make(map[string]int)
 			for i := range nodeStates {
 				state := getNodeUpgradeState(nodeStates[i].Node)
@@ -510,7 +563,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				},
 			}
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			stateCount := make(map[string]int)
 			for _, state := range append(upgradeRequiredNodes, cordonRequiredNodes...) {
 				state := getNodeUpgradeState(state.Node)
@@ -545,7 +598,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				},
 			}
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			stateCount := make(map[string]int)
 			for _, state := range append(upgradeRequiredNodes, cordonRequiredNodes...) {
 				state := getNodeUpgradeState(state.Node)
@@ -556,7 +609,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				stateCount[upgrade.UpgradeStateWaitForJobsRequired]).To(Equal(4))
 		})
 		It("UpgradeStateManager should skip pod deletion if no filter is provided to PodManager at contruction", func() {
-			ctx := context.TODO()
+			testCtx := context.TODO()
 
 			clusterState := upgrade.NewClusterUpgradeState()
 			clusterState.NodeStates[upgrade.UpgradeStateWaitForJobsRequired] = []*upgrade.NodeUpgradeState{
@@ -569,13 +622,13 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				AutoUpgrade: true,
 			}
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policyWithNoDrainSpec)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policyWithNoDrainSpec)).To(Succeed())
 			for _, state := range clusterState.NodeStates[upgrade.UpgradeStateWaitForJobsRequired] {
 				Expect(getNodeUpgradeState(state.Node)).To(Equal(upgrade.UpgradeStateDrainRequired))
 			}
 		})
 		It("UpgradeStateManager should not skip pod deletion if a filter is provided to PodManager at contruction", func() {
-			ctx := context.TODO()
+			testCtx := context.TODO()
 
 			clusterState := upgrade.NewClusterUpgradeState()
 			clusterState.NodeStates[upgrade.UpgradeStateWaitForJobsRequired] = []*upgrade.NodeUpgradeState{
@@ -589,17 +642,17 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			}
 
 			filter := func(pod corev1.Pod) bool { return false }
-			stateManager = stateManager.WithPodDeletionEnabled(filter).(*upgrade.ClusterUpgradeStateManagerImpl)
-			Expect(stateManager.IsPodDeletionEnabled()).To(Equal(true))
+			commonStateManager := stateManager.WithPodDeletionEnabled(filter)
+			Expect(commonStateManager.IsPodDeletionEnabled()).To(Equal(true))
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policyWithNoDrainSpec)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policyWithNoDrainSpec)).To(Succeed())
 			for _, state := range clusterState.NodeStates[upgrade.UpgradeStateWaitForJobsRequired] {
 				Expect(getNodeUpgradeState(state.Node)).To(Equal(upgrade.UpgradeStatePodDeletionRequired))
 			}
 
 		})
 		It("UpgradeStateManager should not attempt to delete pods if pod deletion is disabled", func() {
-			ctx := context.TODO()
+			testCtx := context.TODO()
 
 			clusterState := upgrade.NewClusterUpgradeState()
 			nodes := []*upgrade.NodeUpgradeState{
@@ -619,19 +672,19 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			podManagerMock := mocks.PodManager{}
 			podManagerMock.
 				On("SchedulePodEviction", mock.Anything, mock.Anything).
-				Return(func(ctx context.Context, config *upgrade.PodManagerConfig) error {
+				Return(func(testCtx context.Context, config *upgrade.PodManagerConfig) error {
 					podEvictionCalled = true
 					return nil
 				}).
 				On("SchedulePodsRestart", mock.Anything, mock.Anything).
-				Return(func(ctx context.Context, pods []*corev1.Pod) error {
+				Return(func(testCtx context.Context, pods []*corev1.Pod) error {
 					return nil
 				})
 			stateManager.PodManager = &podManagerMock
 
 			Eventually(podEvictionCalled).ShouldNot(Equal(true))
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policyWithNoPodDeletionSpec)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policyWithNoPodDeletionSpec)).To(Succeed())
 			for _, state := range nodes {
 				Expect(getNodeUpgradeState(state.Node)).To(Equal(upgrade.UpgradeStateDrainRequired))
 			}
@@ -655,7 +708,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				},
 			}
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policyWithNoDrainSpec)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policyWithNoDrainSpec)).To(Succeed())
 			for _, state := range clusterState.NodeStates[upgrade.UpgradeStateDrainRequired] {
 				Expect(getNodeUpgradeState(state.Node)).To(Equal(upgrade.UpgradeStatePodRestartRequired))
 			}
@@ -665,7 +718,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				{Node: nodeWithUpgradeState(upgrade.UpgradeStateDrainRequired)},
 				{Node: nodeWithUpgradeState(upgrade.UpgradeStateDrainRequired)},
 			}
-			Expect(stateManager.ApplyState(ctx, &clusterState, policyWithDisabledDrain)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policyWithDisabledDrain)).To(Succeed())
 			for _, state := range clusterState.NodeStates[upgrade.UpgradeStateDrainRequired] {
 				Expect(getNodeUpgradeState(state.Node)).To(Equal(upgrade.UpgradeStatePodRestartRequired))
 			}
@@ -691,18 +744,18 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			drainManagerMock := mocks.DrainManager{}
 			drainManagerMock.
 				On("ScheduleNodesDrain", mock.Anything, mock.Anything).
-				Return(func(ctx context.Context, config *upgrade.DrainConfiguration) error {
+				Return(func(testCtx context.Context, config *upgrade.DrainConfiguration) error {
 					Expect(config.Spec).To(Equal(&expectedDrainSpec))
 					Expect(config.Nodes).To(HaveLen(3))
 					return nil
 				})
 			stateManager.DrainManager = &drainManagerMock
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, &policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, &policy)).To(Succeed())
 
 			policy.DrainSpec.PodSelector = "test-label=test-value"
 			expectedDrainSpec.PodSelector = policy.DrainSpec.PodSelector
-			Expect(stateManager.ApplyState(ctx, &clusterState, &policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, &policy)).To(Succeed())
 		})
 		It("UpgradeStateManager should fail if drain manager returns an error", func() {
 			clusterState := upgrade.NewClusterUpgradeState()
@@ -722,12 +775,12 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			drainManagerMock := mocks.DrainManager{}
 			drainManagerMock.
 				On("ScheduleNodesDrain", mock.Anything, mock.Anything).
-				Return(func(ctx context.Context, config *upgrade.DrainConfiguration) error {
+				Return(func(testCtx context.Context, config *upgrade.DrainConfiguration) error {
 					return errors.New("drain failed")
 				})
 			stateManager.DrainManager = &drainManagerMock
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).ToNot(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).ToNot(Succeed())
 		})
 		It("UpgradeStateManager should not restart pod if it's up to date or already terminating", func() {
 			daemonSet := &appsv1.DaemonSet{ObjectMeta: v1.ObjectMeta{}}
@@ -768,18 +821,18 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			podManagerMock := mocks.PodManager{}
 			podManagerMock.
 				On("SchedulePodsRestart", mock.Anything, mock.Anything).
-				Return(func(ctx context.Context, podsToDelete []*corev1.Pod) error {
+				Return(func(testCtx context.Context, podsToDelete []*corev1.Pod) error {
 					Expect(podsToDelete).To(HaveLen(1))
 					Expect(podsToDelete[0]).To(Equal(outdatedRunningPod))
 					return nil
 				})
 			podManagerMock.
-				On("GetPodControllerRevisionHash", mock.Anything, mock.Anything).
+				On("GetPodControllerRevisionHash", mock.Anything).
 				Return(
-					func(ctx context.Context, pod *corev1.Pod) string {
+					func(pod *corev1.Pod) string {
 						return pod.Labels[upgrade.PodControllerRevisionHashLabelKey]
 					},
-					func(ctx context.Context, pod *corev1.Pod) error {
+					func(pod *corev1.Pod) error {
 						return nil
 					},
 				)
@@ -788,7 +841,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				Return("test-hash-12345", nil)
 			stateManager.PodManager = &podManagerMock
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 		})
 		It("UpgradeStateManager should unblock loading of the driver instead of restarting the Pod when node "+
 			"is waiting for safe driver loading", func() {
@@ -819,8 +872,8 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
 			stateManager.NodeUpgradeStateProvider = provider
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: waitForSafeLoadNode.Name}, waitForSafeLoadNode)).
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: waitForSafeLoadNode.Name}, waitForSafeLoadNode)).
 				NotTo(HaveOccurred())
 			Expect(waitForSafeLoadNode.Annotations[safeLoadAnnotation]).To(BeEmpty())
 		})
@@ -856,13 +909,13 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				AutoUpgrade: true,
 			}
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			Expect(getNodeUpgradeState(podRestartNode)).To(Equal(upgrade.UpgradeStateUncordonRequired))
 			Expect(getNodeUpgradeState(upgradeFailedNode)).To(Equal(upgrade.UpgradeStateUncordonRequired))
 		})
 		It("UpgradeStateManager should move pod to UpgradeDone state "+
 			"if it's in PodRestart or UpgradeFailed, driver pod is up-to-date and ready, and node was initially Unschedulable", func() {
-			ctx := context.TODO()
+			testCtx := context.TODO()
 
 			daemonSet := &appsv1.DaemonSet{ObjectMeta: v1.ObjectMeta{}}
 			pod := &corev1.Pod{
@@ -905,7 +958,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
 			stateManager.NodeUpgradeStateProvider = provider
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			Expect(getNodeUpgradeState(podRestartNode)).To(Equal(upgrade.UpgradeStateDone))
 			Expect(getNodeUpgradeState(upgradeFailedNode)).To(Equal(upgrade.UpgradeStateDone))
 			// unschedulable annotation should be removed
@@ -952,7 +1005,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				AutoUpgrade: true,
 			}
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			Expect(getNodeUpgradeState(nodes[0])).To(Equal(upgrade.UpgradeStatePodRestartRequired))
 			Expect(getNodeUpgradeState(nodes[1])).To(Equal(upgrade.UpgradeStatePodRestartRequired))
 			Expect(getNodeUpgradeState(nodes[2])).To(Equal(upgrade.UpgradeStateFailed))
@@ -960,7 +1013,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 		})
 		It("UpgradeStateManager should move pod to UpgradeValidationRequired state "+
 			"if it's in PodRestart, driver pod is up-to-date and ready, and validation is enabled", func() {
-			ctx := context.TODO()
+			testCtx := context.TODO()
 
 			daemonSet := &appsv1.DaemonSet{ObjectMeta: v1.ObjectMeta{}}
 			pod := &corev1.Pod{
@@ -985,19 +1038,18 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			policy := &v1alpha1.DriverUpgradePolicySpec{
 				AutoUpgrade: true,
 			}
-
-			stateManager = stateManager.WithValidationEnabled("app=validator").(*upgrade.ClusterUpgradeStateManagerImpl)
-			Expect(stateManager.IsValidationEnabled()).To(Equal(true))
+			commonStateManager := stateManager.WithValidationEnabled("app=validator")
+			Expect(commonStateManager.IsValidationEnabled()).To(Equal(true))
 			// do not mock NodeUpgradeStateProvider as it is used during ProcessUpgradeValidationRequiredNodes()
 			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
 			stateManager.NodeUpgradeStateProvider = provider
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			Expect(getNodeUpgradeState(podRestartNode)).To(Equal(upgrade.UpgradeStateValidationRequired))
 		})
 		It("UpgradeStateManager should move pod to UpgradeUncordonRequired state "+
 			"if it's in ValidationRequired and validation has completed", func() {
-			ctx := context.TODO()
+			testCtx := context.TODO()
 
 			node := NewNode(fmt.Sprintf("node1-%s", id)).
 				WithUpgradeState(upgrade.UpgradeStateValidationRequired).
@@ -1021,18 +1073,18 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				AutoUpgrade: true,
 			}
 
-			stateManager = stateManager.WithValidationEnabled("app=validator").(*upgrade.ClusterUpgradeStateManagerImpl)
-			Expect(stateManager.IsValidationEnabled()).To(Equal(true))
+			commonStateManager := stateManager.WithValidationEnabled("app=validator")
+			Expect(commonStateManager.IsValidationEnabled()).To(Equal(true))
 			// do not mock NodeUpgradeStateProvider as it is used during ProcessUpgradeValidationRequiredNodes()
 			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
 			stateManager.NodeUpgradeStateProvider = provider
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			Expect(getNodeUpgradeState(node)).To(Equal(upgrade.UpgradeStateUncordonRequired))
 		})
 		It("UpgradeStateManager should move pod to UpgradeDone state"+
 			"if it's in ValidationRequired, validation has completed, and node was initially Unschedulable", func() {
-			ctx := context.TODO()
+			testCtx := context.TODO()
 
 			node := NewNode(fmt.Sprintf("node1-%s", id)).
 				WithUpgradeState(upgrade.UpgradeStateValidationRequired).
@@ -1058,13 +1110,13 @@ var _ = Describe("UpgradeStateManager tests", func() {
 				AutoUpgrade: true,
 			}
 
-			stateManager = stateManager.WithValidationEnabled("app=validator").(*upgrade.ClusterUpgradeStateManagerImpl)
-			Expect(stateManager.IsValidationEnabled()).To(Equal(true))
+			commonStateManager := stateManager.WithValidationEnabled("app=validator")
+			Expect(commonStateManager.IsValidationEnabled()).To(Equal(true))
 			// do not mock NodeUpgradeStateProvider as it is used during ProcessUpgradeValidationRequiredNodes()
 			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
 			stateManager.NodeUpgradeStateProvider = provider
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			Expect(getNodeUpgradeState(node)).To(Equal(upgrade.UpgradeStateDone))
 			// unschedulable annotation should be removed
 			Expect(isUnschedulableAnnotationPresent(node)).To(Equal(false))
@@ -1086,13 +1138,13 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			cordonManagerMock := mocks.CordonManager{}
 			cordonManagerMock.
 				On("Uncordon", mock.Anything, mock.Anything, mock.Anything).
-				Return(func(ctx context.Context, node *corev1.Node) error {
+				Return(func(testCtx context.Context, node *corev1.Node) error {
 					Expect(node).To(Equal(node))
 					return nil
 				})
 			stateManager.CordonManager = &cordonManagerMock
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 			Expect(getNodeUpgradeState(node)).To(Equal(upgrade.UpgradeStateDone))
 		})
 		It("UpgradeStateManager should fail if cordonManager fails", func() {
@@ -1112,12 +1164,12 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			cordonManagerMock := mocks.CordonManager{}
 			cordonManagerMock.
 				On("Uncordon", mock.Anything, mock.Anything, mock.Anything).
-				Return(func(ctx context.Context, node *corev1.Node) error {
+				Return(func(testCtx context.Context, node *corev1.Node) error {
 					return errors.New("cordonManagerFailed")
 				})
 			stateManager.CordonManager = &cordonManagerMock
 
-			Expect(stateManager.ApplyState(ctx, &clusterState, policy)).ToNot(Succeed())
+			Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).ToNot(Succeed())
 			Expect(getNodeUpgradeState(node)).ToNot(Equal(upgrade.UpgradeStateDone))
 		})
 	})
@@ -1137,7 +1189,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 		clusterState.NodeStates[""] = unknownNodes
 		clusterState.NodeStates[upgrade.UpgradeStateDone] = doneNodes
 
-		Expect(stateManager.ApplyState(ctx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
 		Expect(getNodeUpgradeState(UnknownToUpgradeDoneNode)).To(Equal(upgrade.UpgradeStateDone))
 		Expect(getNodeUpgradeState(DoneToUpgradeDoneNode)).To(Equal(upgrade.UpgradeStateDone))
 	})
@@ -1159,7 +1211,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 		clusterState.NodeStates[""] = unknownNodes
 		clusterState.NodeStates[upgrade.UpgradeStateDone] = doneNodes
 
-		Expect(stateManager.ApplyState(ctx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
 		Expect(getNodeUpgradeState(UnknownToUpgradeRequiredNode)).To(Equal(upgrade.UpgradeStateUpgradeRequired))
 		Expect(getNodeUpgradeState(DoneToUpgradeRequiredNode)).To(Equal(upgrade.UpgradeStateUpgradeRequired))
 	})
@@ -1175,7 +1227,7 @@ var _ = Describe("UpgradeStateManager tests", func() {
 		}
 		clusterState.NodeStates[upgrade.UpgradeStateUpgradeRequired] = upgradeRequiredNodes
 
-		Expect(stateManager.ApplyState(ctx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
 		Expect(getNodeUpgradeState(UpgradeRequiredToCordonNodes)).To(Equal(upgrade.UpgradeStateCordonRequired))
 		Expect(UpgradeRequiredToCordonNodes.Annotations[upgrade.GetUpgradeRequestedAnnotationKey()]).To(Equal(""))
 	})
@@ -1200,14 +1252,14 @@ var _ = Describe("UpgradeStateManager tests", func() {
 		podManagerMock := mocks.PodManager{}
 		podManagerMock.
 			On("SchedulePodsRestart", mock.Anything, mock.Anything).
-			Return(func(ctx context.Context, podsToDelete []*corev1.Pod) error {
+			Return(func(testCtx context.Context, podsToDelete []*corev1.Pod) error {
 				Expect(podsToDelete).To(HaveLen(1))
 				Expect(podsToDelete[0]).To(Equal(orphanedPod))
 				return nil
 			})
 		stateManager.PodManager = &podManagerMock
 
-		Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 	})
 	It("UpgradeStateManager should not move to UncordonRequired state "+
 		"if it's in UpgradeFailed, and Orphaned Pod", func() {
@@ -1233,8 +1285,357 @@ var _ = Describe("UpgradeStateManager tests", func() {
 			AutoUpgrade: true,
 		}
 
-		Expect(stateManager.ApplyState(ctx, &clusterState, policy)).To(Succeed())
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
 		Expect(getNodeUpgradeState(upgradeFailedNode)).To(Equal(upgrade.UpgradeStateFailed))
+	})
+
+	It("UpgradeStateManager should move to 'node-maintenance-required' while using upgrade requestor mode", func() {
+		namespace := createNamespace(fmt.Sprintf("namespace-%s", id)).Name
+		cancel := withUpgradeRequestorMode(testCtx, namespace)
+		defer cancel()
+
+		clusterState := withClusterUpgradeState(3, upgrade.UpgradeStateUpgradeRequired, namespace, nil, false)
+		policy := &v1alpha1.DriverUpgradePolicySpec{
+			AutoUpgrade: true,
+			DrainSpec: &v1alpha1.DrainSpec{
+				Enable: true,
+			},
+		}
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
+
+		By("verify node requestor-mode-annotation")
+		Eventually(func() bool {
+			for _, nodeState := range clusterState.NodeStates[upgrade.UpgradeStateUpgradeRequired] {
+				node := corev1.Node{}
+				nodeKey := client.ObjectKey{
+					Name: nodeState.Node.Name,
+				}
+				if err := k8sClient.Get(testCtx, nodeKey, &node); err != nil {
+					if _, ok := node.Annotations[upgrade.GetUpgradeRequestorModeAnnotationKey()]; !ok {
+						return false
+					}
+				}
+				Expect(node.Annotations[upgrade.GetUpgradeRequestorModeAnnotationKey()]).To(Equal("true"))
+			}
+			return true
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(BeTrue())
+
+		By("verify generated node-maintenance obj(s)")
+		nms := &maintenancev1alpha1.NodeMaintenanceList{}
+		Eventually(func() bool {
+			k8sClient.List(testCtx, nms)
+			return len(nms.Items) == len(clusterState.NodeStates[upgrade.UpgradeStateUpgradeRequired])
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(BeTrue())
+
+		By("set node-maintenance(s) finalizer to mimic maintenance-operator obj deletion ownership")
+		for _, item := range nms.Items {
+			nm := &maintenancev1alpha1.NodeMaintenance{}
+			err := k8sClient.Get(testCtx, client.ObjectKey{Name: item.Name, Namespace: namespace}, nm)
+			Expect(err).NotTo(HaveOccurred())
+
+			nm.Finalizers = append(nm.Finalizers, maintenancev1alpha1.MaintenanceFinalizerName)
+			err = k8sClient.Update(testCtx, nm)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() error {
+				nm := &maintenancev1alpha1.NodeMaintenance{}
+				err := k8sClient.Get(testCtx, client.ObjectKey{Name: item.Name, Namespace: namespace}, nm)
+				if err != nil {
+					return err
+				}
+				if len(nm.Finalizers) == 0 {
+					return fmt.Errorf("missing status condition")
+				}
+				return nil
+			}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(Succeed())
+		}
+
+		By("verify node is in 'node-maintennace-required' state")
+		nodes := &corev1.NodeList{}
+		Eventually(func() error {
+			k8sClient.List(testCtx, nodes)
+			for _, node := range nodes.Items {
+				if getNodeUpgradeState(&node) != upgrade.UpgradeStateNodeMaintenanceRequired {
+					return fmt.Errorf("missing status condition")
+				}
+			}
+			return nil
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(Succeed())
+	})
+
+	It("UpgradeStateManager should move to 'post-maintenance-required' while using upgrade requestor mode", func() {
+		namespace := createNamespace(fmt.Sprintf("namespace-%s", id)).Name
+		cancel := withUpgradeRequestorMode(testCtx, namespace)
+		defer cancel()
+
+		clusterState := withClusterUpgradeState(1, upgrade.UpgradeStateNodeMaintenanceRequired, namespace,
+			map[string]string{upgrade.GetUpgradeRequestedAnnotationKey(): "true"}, true)
+		policy := &v1alpha1.DriverUpgradePolicySpec{
+			AutoUpgrade: true,
+			DrainSpec: &v1alpha1.DrainSpec{
+				Enable: true,
+			},
+		}
+
+		// eventually wait for node to be created
+		node := &corev1.Node{}
+		Eventually(func() error {
+			err := k8sClient.Get(testCtx, client.ObjectKey{Name: "node-1", Namespace: namespace}, node)
+			if err != nil {
+				return err
+			}
+			return nil
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(Succeed())
+
+		nmObj := &maintenancev1alpha1.NodeMaintenance{}
+		err := k8sClient.Get(testCtx, client.ObjectKey{Name: "node-1", Namespace: namespace}, nmObj)
+		Expect(err).NotTo(HaveOccurred())
+		By("set node-maintenance(s) status to mimic maintenance-operator 'Ready' condition flow")
+		status := maintenancev1alpha1.NodeMaintenanceStatus{
+			Conditions: []v1.Condition{{
+				Type:               maintenancev1alpha1.ConditionTypeReady,
+				Status:             v1.ConditionTrue,
+				Reason:             maintenancev1alpha1.ConditionReasonReady,
+				Message:            "Maintenance completed successfully",
+				LastTransitionTime: v1.NewTime(time.Now()),
+			}},
+		}
+		nmObj.Status = status
+		err = k8sClient.Status().Update(testCtx, nmObj)
+		Expect(err).NotTo(HaveOccurred())
+
+		nm := &maintenancev1alpha1.NodeMaintenance{}
+		Eventually(func() error {
+			err := k8sClient.Get(testCtx, client.ObjectKey{Name: "node-1", Namespace: namespace}, nm)
+			if err != nil {
+				return err
+			}
+			if len(nm.Status.Conditions) == 0 {
+				return fmt.Errorf("missing status condition. '%v'", nm.DeepCopy().Status)
+			}
+			return nil
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(Succeed())
+		clusterState.NodeStates[upgrade.UpgradeStateNodeMaintenanceRequired][0].NodeMaintenance = nm
+
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
+
+		By("verify node is in post-maintenace-required' state")
+		node = &corev1.Node{}
+		Eventually(func() error {
+			err := k8sClient.Get(testCtx, client.ObjectKey{Name: "node-1", Namespace: namespace}, node)
+			if err != nil {
+				return err
+			}
+			if getNodeUpgradeState(node) != upgrade.UpgradeStatePodRestartRequired {
+				return fmt.Errorf("missing status condition")
+			}
+			return nil
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(Succeed())
+
+	})
+
+	It("UpgradeStateManager should move node to 'upgrade-required' in case nodeMaintenance obj is missing "+
+		"while using upgrade requestor mode", func() {
+		namespace := createNamespace(fmt.Sprintf("namespace-%s", id)).Name
+		cancel := withUpgradeRequestorMode(testCtx, namespace)
+		defer cancel()
+
+		clusterState := withClusterUpgradeState(1, upgrade.UpgradeStateNodeMaintenanceRequired, namespace,
+			map[string]string{upgrade.GetUpgradeRequestedAnnotationKey(): "true"}, true)
+		policy := &v1alpha1.DriverUpgradePolicySpec{
+			AutoUpgrade: true,
+			DrainSpec: &v1alpha1.DrainSpec{
+				Enable: true,
+			},
+		}
+
+		// eventually wait for node to be created
+		node := &corev1.Node{}
+		Eventually(func() error {
+			err := k8sClient.Get(testCtx, client.ObjectKey{Name: "node-1", Namespace: namespace}, node)
+			if err != nil {
+				return err
+			}
+			return nil
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(Succeed())
+
+		clusterState.NodeStates[upgrade.UpgradeStateNodeMaintenanceRequired][0].NodeMaintenance = nil
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
+
+		By("verify node is in 'upgrade-required' state")
+		node = &corev1.Node{}
+		Eventually(func() error {
+			err := k8sClient.Get(testCtx, client.ObjectKey{Name: "node-1", Namespace: namespace}, node)
+			if err != nil {
+				return err
+			}
+			if getNodeUpgradeState(node) != upgrade.UpgradeStateUpgradeRequired {
+				return fmt.Errorf("missing status condition")
+			}
+			return nil
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(Succeed())
+
+	})
+
+	It("UpgradeStateManager continue inplace upgrade logic, move to 'wait-for-jobs-required' "+
+		"while using upgrade requestor mode", func() {
+		namespace := createNamespace(fmt.Sprintf("namespace-%s", id)).Name
+		cancel := withUpgradeRequestorMode(testCtx, namespace)
+		defer cancel()
+
+		clusterState := withClusterUpgradeState(3, upgrade.UpgradeStateCordonRequired, namespace, nil, true)
+		policy := &v1alpha1.DriverUpgradePolicySpec{
+			AutoUpgrade: true,
+			DrainSpec: &v1alpha1.DrainSpec{
+				Enable: true,
+			},
+		}
+
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
+		By("verify node is in wait-for-jobs-required' state")
+		node := &corev1.Node{}
+		Eventually(func() error {
+			err := k8sClient.Get(testCtx, client.ObjectKey{Name: "node-1", Namespace: namespace}, node)
+			if err != nil {
+				return err
+			}
+			if getNodeUpgradeState(node) != upgrade.UpgradeStateWaitForJobsRequired {
+				return fmt.Errorf("missing status condition")
+			}
+			return nil
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(Succeed())
+
+	})
+
+	It("UpgradeStateManager move to 'upgrade-done' using upgrade requestor mode", func() {
+		namespace := createNamespace(fmt.Sprintf("namespace-%s", id)).Name
+		cancel := withUpgradeRequestorMode(testCtx, namespace)
+		defer cancel()
+
+		clusterState := withClusterUpgradeState(3, upgrade.UpgradeStateUncordonRequired, namespace,
+			map[string]string{upgrade.GetUpgradeRequestedAnnotationKey(): "true"}, true)
+		policy := &v1alpha1.DriverUpgradePolicySpec{
+			AutoUpgrade: true,
+			DrainSpec: &v1alpha1.DrainSpec{
+				Enable: true,
+			},
+		}
+
+		By("verify node-maintenance obj(s) have been deleted")
+		nms := &maintenancev1alpha1.NodeMaintenanceList{}
+		Eventually(func() bool {
+			k8sClient.List(testCtx, nms)
+			return len(nms.Items) == len(clusterState.NodeStates[upgrade.UpgradeStateUncordonRequired])
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(BeTrue())
+
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
+		By("verify node is in 'upgrade-done' state")
+		node := &corev1.Node{}
+		Eventually(func() error {
+			err := k8sClient.Get(testCtx, client.ObjectKey{Name: "node-2", Namespace: namespace}, node)
+			if err != nil {
+				return err
+			}
+			if getNodeUpgradeState(node) != upgrade.UpgradeStateDone {
+				return fmt.Errorf("missing status condition")
+			}
+			return nil
+		}).WithTimeout(10 * time.Second).WithPolling(1 * 500 * time.Millisecond).Should(Succeed())
+
+	})
+
+	It("UpgradeStateManager should move outdated node to UpgradeRequired states with orphaned pod if 'upgrade-requested' "+
+		"while using upgrade requestor mode", func() {
+		namespace := createNamespace(fmt.Sprintf("namespace-%s", id)).Name
+		cancel := withUpgradeRequestorMode(testCtx, namespace)
+		defer cancel()
+
+		orphanedPod := &corev1.Pod{}
+		UnknownToUpgradeRequiredNode := NewNode("node-1").WithUpgradeState(upgrade.UpgradeStateUnknown).
+			WithAnnotations(map[string]string{upgrade.GetUpgradeRequestedAnnotationKey(): "true"}).Create()
+		DoneToUpgradeRequiredNode := NewNode("node-2").WithUpgradeState(upgrade.UpgradeStateDone).
+			WithAnnotations(map[string]string{upgrade.GetUpgradeRequestedAnnotationKey(): "true"}).Create()
+
+		clusterState := upgrade.NewClusterUpgradeState()
+		unknownNodes := []*upgrade.NodeUpgradeState{
+			{Node: UnknownToUpgradeRequiredNode, DriverPod: orphanedPod, DriverDaemonSet: nil},
+		}
+		doneNodes := []*upgrade.NodeUpgradeState{
+			{Node: DoneToUpgradeRequiredNode, DriverPod: orphanedPod, DriverDaemonSet: nil},
+		}
+		clusterState.NodeStates[upgrade.UpgradeStateUnknown] = unknownNodes
+		clusterState.NodeStates[upgrade.UpgradeStateDone] = doneNodes
+
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
+		Expect(getNodeUpgradeState(UnknownToUpgradeRequiredNode)).To(Equal(upgrade.UpgradeStateUpgradeRequired))
+		Expect(getNodeUpgradeState(DoneToUpgradeRequiredNode)).To(Equal(upgrade.UpgradeStateUpgradeRequired))
+	})
+
+	It("UpgradeStateManager should move up-to-date nodes with safe driver loading annotation "+
+		"to UpgradeRequired state, while using upgrade requestor mode", func() {
+		namespace := createNamespace(fmt.Sprintf("namespace-%s", id)).Name
+		cancel := withUpgradeRequestorMode(testCtx, namespace)
+		defer cancel()
+
+		safeLoadAnnotationKey := upgrade.GetUpgradeDriverWaitForSafeLoadAnnotationKey()
+		daemonSet := &appsv1.DaemonSet{ObjectMeta: v1.ObjectMeta{}}
+		upToDatePod := &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{Labels: map[string]string{upgrade.PodControllerRevisionHashLabelKey: "test-hash-12345"}}}
+
+		waitForSafeLoadNode := NewNode(fmt.Sprintf("node1-%s", id)).
+			WithAnnotations(map[string]string{safeLoadAnnotationKey: "true"}).
+			Create()
+		clusterState := upgrade.NewClusterUpgradeState()
+		clusterState.NodeStates[upgrade.UpgradeStateDone] = []*upgrade.NodeUpgradeState{{
+			Node: waitForSafeLoadNode, DriverPod: upToDatePod, DriverDaemonSet: daemonSet,
+		}}
+
+		provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
+		stateManager.NodeUpgradeStateProvider = provider
+
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, &v1alpha1.DriverUpgradePolicySpec{AutoUpgrade: true})).To(Succeed())
+		Expect(getNodeUpgradeState(waitForSafeLoadNode)).To(Equal(upgrade.UpgradeStateUpgradeRequired))
+	})
+	It("UpgradeStateManager should move pod to UpgradeDone state"+
+		"if it's in ValidationRequired, validation has completed, and node was initially Unschedulable "+
+		"while using upgrade requestor mode", func() {
+		namespace := createNamespace(fmt.Sprintf("namespace-%s", id)).Name
+		cancel := withUpgradeRequestorMode(testCtx, namespace)
+		defer cancel()
+
+		node := NewNode(fmt.Sprintf("node1-%s", id)).
+			WithUpgradeState(upgrade.UpgradeStateValidationRequired).
+			WithAnnotations(map[string]string{upgrade.GetUpgradeInitialStateAnnotationKey(): "true"}).
+			Unschedulable(true).
+			Create()
+
+		_ = NewPod(fmt.Sprintf("pod-%s", id), namespace, node.Name).
+			WithLabels(map[string]string{"app": "validator"}).
+			Create()
+
+		clusterState := upgrade.NewClusterUpgradeState()
+		clusterState.NodeStates[upgrade.UpgradeStateValidationRequired] = []*upgrade.NodeUpgradeState{
+			{
+				Node:            node,
+				DriverPod:       &corev1.Pod{},
+				DriverDaemonSet: &appsv1.DaemonSet{},
+			},
+		}
+
+		policy := &v1alpha1.DriverUpgradePolicySpec{
+			AutoUpgrade: true,
+		}
+
+		commonStateManager := stateManager.WithValidationEnabled("app=validator")
+		Expect(commonStateManager.IsValidationEnabled()).To(Equal(true))
+		// do not mock NodeUpgradeStateProvider as it is used during ProcessUpgradeValidationRequiredNodes()
+		provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
+		stateManager.NodeUpgradeStateProvider = provider
+
+		Expect(stateManagerInterface.ApplyState(testCtx, &clusterState, policy)).To(Succeed())
+		Expect(getNodeUpgradeState(node)).To(Equal(upgrade.UpgradeStateDone))
+		// unschedulable annotation should be removed
+		Expect(isUnschedulableAnnotationPresent(node)).To(Equal(false))
 	})
 
 })
@@ -1246,4 +1647,69 @@ func nodeWithUpgradeState(state string) *corev1.Node {
 			Annotations: map[string]string{},
 		},
 	}
+}
+
+func removeFinalizersOrDelete(testCtx context.Context, nm *maintenancev1alpha1.NodeMaintenance) error {
+	var err error
+	instanceFinalizers := nm.GetFinalizers()
+	if len(instanceFinalizers) == 0 {
+		err = k8sClient.Delete(testCtx, nm)
+		return err
+	}
+
+	nm.SetFinalizers([]string{})
+	err = k8sClient.Update(testCtx, nm)
+	if err != nil && k8serrors.IsNotFound(err) {
+		err = nil
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	return err
+}
+
+func withClusterUpgradeState(nodeCount int, nodeState string, namespace string,
+	annotations map[string]string, withNodeMaintenance bool) upgrade.ClusterUpgradeState {
+	clusterState := upgrade.NewClusterUpgradeState()
+
+	daemonSet := &appsv1.DaemonSet{ObjectMeta: v1.ObjectMeta{}}
+	for i := 1; i <= nodeCount; i++ {
+		nodeName := fmt.Sprintf("node-%d", i)
+		nodeUpgradeState := &upgrade.NodeUpgradeState{
+			Node: NewNode(nodeName).WithUpgradeState(nodeState).
+				WithAnnotations(annotations).Create(),
+			DriverPod:       NewPod(fmt.Sprintf("pod-%d", i), namespace, nodeName).Create(),
+			DriverDaemonSet: daemonSet,
+		}
+		if withNodeMaintenance {
+			nodeUpgradeState.NodeMaintenance = NewNodeMaintenance(nodeName, namespace).Create()
+		}
+		clusterState.NodeStates[nodeState] =
+			append(clusterState.NodeStates[nodeState], nodeUpgradeState)
+	}
+
+	return clusterState
+
+}
+
+func withUpgradeRequestorMode(testCtx context.Context, namespace string) context.CancelFunc {
+	var err error
+	os.Setenv("MAINTENANCE_OPERATOR_ENABLED", "true")
+	os.Setenv("MAINTENANCE_OPERATOR_REQUESTOR_NAMESPACE", namespace)
+	os.Setenv("MAINTENANCE_OPERATOR_REQUESTOR_ID", "network.opeator.com")
+	_, cancelFn := context.WithCancel(testCtx)
+	opts := upgrade.GetRequestorOptsFromEnvs()
+
+	stateManagerInterface, err = upgrade.NewClusterUpgradeStateManager(log, k8sConfig,
+		eventRecorder, upgrade.StateOptions{Requestor: opts})
+	Expect(err).NotTo(HaveOccurred())
+
+	stateManager, _ = stateManagerInterface.(*upgrade.ClusterUpgradeStateManagerImpl)
+	provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
+	stateManager.NodeUpgradeStateProvider = provider
+	stateManager.DrainManager = &drainManager
+	stateManager.CordonManager = &cordonManager
+	stateManager.PodManager = &podManager
+	stateManager.ValidationManager = &validationManager
+
+	return cancelFn
 }

--- a/pkg/upgrade/util.go
+++ b/pkg/upgrade/util.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2022 NVIDIA CORPORATION & AFFILIATES
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -116,6 +119,12 @@ func GetUpgradeRequestedAnnotationKey() string {
 	return fmt.Sprintf(UpgradeRequestedAnnotationKeyFmt, DriverName)
 }
 
+// GetUpgradeRequestorModeAnnotationKey returns the key for annotation used to mark node as requestor upgrade mode
+// in progress
+func GetUpgradeRequestorModeAnnotationKey() string {
+	return fmt.Sprintf(UpgradeRequestorModeAnnotationKeyFmt, DriverName)
+}
+
 // GetUpgradeInitialStateAnnotationKey returns the key for annotation used to track initial state of the node
 func GetUpgradeInitialStateAnnotationKey() string {
 	return fmt.Sprintf(UpgradeInitialStateAnnotationKeyFmt, DriverName)
@@ -138,6 +147,7 @@ func GetEventReason() string {
 	return fmt.Sprintf("%sDriverUpgrade", strings.ToUpper(DriverName))
 }
 
+// logEventf logs a formatted event for a given kubernetes object
 func logEventf(recorder record.EventRecorder, object runtime.Object, eventType string, reason string, messageFmt string,
 	args ...interface{}) {
 	if recorder != nil {
@@ -145,6 +155,7 @@ func logEventf(recorder record.EventRecorder, object runtime.Object, eventType s
 	}
 }
 
+// logEvent logs an event for a given kubernetes object
 func logEvent(recorder record.EventRecorder, object runtime.Object, eventType string, reason string,
 	messageFmt string) {
 	if recorder != nil {


### PR DESCRIPTION
Following PR changes incorporates integration with NVIDIA [maintenance operator](https://github.com/Mellanox/maintenance-operator)

PR include the following changes:
- Restructure upgrade package to accommodate new `requestor` mode. Initially both `inplace`(legacy) as well as `requestor` modes will be supported. The motivation is to use `requestor` and retire upgrade logic from GPU/Network operators.
- Adding upgrade `requestor` package support