### PR TITLE
migrate to golangci-lint v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,25 +1,9 @@
+version: "2"
 run:
-  timeout: 10m
-  # If set we pass it to "go list -mod={option}". From "go help modules":
-  # If invoked with -mod=readonly, the go command is disallowed from the implicit
-  # automatic updating of go.mod described above. Instead, it fails when any changes
-  # to go.mod are needed. This setting is most useful to check that go.mod does
-  # not need updates, such as in a continuous integration and testing system.
-  # If invoked with -mod=vendor, the go command assumes that the vendor
-  # directory holds the correct copies of dependencies and ignores
-  # the dependency descriptions in go.mod.
-  #
-  # Allowed values: readonly|vendor|mod
-  # By default, it isn't set.
   modules-download-mode: readonly
   tests: false
-
 linters:
-  disable-all: true
-  # Enable specific linter
-  # https://golangci-lint.run/usage/linters/#enabled-by-default
-  # Note(adrianc): some linters below are disabled, each should be enabled, evaluated for its contribution
-  # to code quality of the project and discovered issues to be fixed.
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -27,7 +11,6 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
-    #- cyclop
     - decorder
     - depguard
     - dogsled
@@ -35,23 +18,16 @@ linters:
     - errcheck
     - errchkjson
     - errname
-    #- errorlint
     - forbidigo
     - forcetypeassert
     - funlen
-    #- gocognit
     - goconst
     - gocritic
     - gocyclo
-    #- goerr113
-    - gofmt
     - goheader
-    - goimports
-    #- gomnd
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - grouper
     - importas
@@ -63,7 +39,6 @@ linters:
     - makezero
     - misspell
     - nakedret
-    #- nestif
     - nilerr
     - nilnil
     - noctx
@@ -76,63 +51,76 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
-    - stylecheck
-    - tenv
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
     - wastedassign
     - whitespace
-    #- wsl
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        list-mode: original
-        allow:
-          - $gostd
-          - github.com/NVIDIA
-          - github.com/go-logr/logr
-          - k8s.io
-          - sigs.k8s.io
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 120
-    statements: 58
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocyclo:
-    min-complexity: 30
-  goimports:
-    local-prefixes: github.com/NVIDIA/k8s-operator-libs
-  lll:
-    line-length: 120
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: [argument,case,condition,return]
-  misspell:
-    locale: US
-  stylecheck:
-    dot-import-whitelist:
-      - github.com/onsi/ginkgo
-      - github.com/onsi/ginkgo/extensions/table
-      - github.com/onsi/gomega
-      - github.com/onsi/gomega/gstruct
-  gocritic:
-    disabled-checks:
-      - appendAssign
-  ireturn:
-    allow:
-      - anon
-      - error
-      - empty
-      - stdlib
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: original
+          allow:
+            - $gostd
+            - github.com/NVIDIA
+            - github.com/go-logr/logr
+            - k8s.io
+            - sigs.k8s.io
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 120
+      statements: 58
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - appendAssign
+    gocyclo:
+      min-complexity: 30
+    ireturn:
+      allow:
+        - anon
+        - error
+        - empty
+        - stdlib
+    lll:
+      line-length: 120
+    misspell:
+      locale: US
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/onsi/ginkgo
+        - github.com/onsi/ginkgo/extensions/table
+        - github.com/onsi/gomega
+        - github.com/onsi/gomega/gstruct
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/NVIDIA/k8s-operator-libs
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ GOLANGCILINT ?= $(TOOLSDIR)/golangci-lint
 CONTROLLER_GEN ?= $(TOOLSDIR)/controller-gen
 GCOV2LCOV ?= $(TOOLSDIR)/gcov2lcov
 SETUP_ENVTEST ?= $(TOOLSDIR)/setup-envtest
-GOLANGCILINT_VERSION ?= v1.62.2
+GOLANGCILINT_VERSION ?= v2.1.6
 CONTROLLER_GEN_VERSION ?= v0.16.5
 GCOV2LCOV_VERSION ?= v1.1.1
 SETUP_ENVTEST_RELEASE ?= release-0.19
@@ -84,7 +84,7 @@ controller-gen:	## Download controller-gen locally if necessary
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION))
 
 golangci-lint: ## Download golangci-lint locally if necessary.
-	$(call go-install-tool,$(GOLANGCILINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCILINT_VERSION))
+	$(call go-install-tool,$(GOLANGCILINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCILINT_VERSION))
 
 gcov2lcov: ## Download gcov2lcov locally if necessary.
 	$(call go-install-tool,$(GCOV2LCOV),github.com/jandelgado/gcov2lcov@$(GCOV2LCOV_VERSION))

--- a/pkg/upgrade/common_manager.go
+++ b/pkg/upgrade/common_manager.go
@@ -221,7 +221,7 @@ func (m *CommonUpgradeManagerImpl) GetOrphanedPods(pods []corev1.Pod) []corev1.P
 }
 
 func IsOrphanedPod(pod *corev1.Pod) bool {
-	return pod.OwnerReferences == nil || len(pod.OwnerReferences) < 1
+	return len(pod.OwnerReferences) < 1
 }
 
 // ProcessDoneOrUnknownNodes iterates over UpgradeStateDone or UpgradeStateUnknown nodes and determines
@@ -469,7 +469,7 @@ func (m *CommonUpgradeManagerImpl) ProcessPodRestartNodes(
 			// Pods should only be scheduled for restart if they are not terminating or restarting already
 			// To determinate terminating state we need to check for deletion timestamp which will be set
 			// once pod termination process started
-			if nodeState.DriverPod.ObjectMeta.DeletionTimestamp.IsZero() {
+			if nodeState.DriverPod.DeletionTimestamp.IsZero() {
 				pods = append(pods, nodeState.DriverPod)
 			}
 		} else {


### PR DESCRIPTION
This PR also fixes the following linting issues reported by v2 of golangci-lint

```
Error: pkg/upgrade/common_manager.go:224:9: S1009: should omit nil check; len() for nil slices is defined as zero (staticcheck)
	return pod.OwnerReferences == nil || len(pod.OwnerReferences) < 1
	       ^
Error: pkg/upgrade/common_manager.go:472:27: QF1008: could remove embedded field "ObjectMeta" from selector (staticcheck)
			if nodeState.DriverPod.ObjectMeta.DeletionTimestamp.IsZero() {
```