### PR TITLE
upgrade: evict additional GPU consumers via PodDeletionSpec.PodSelector

### DIFF
--- a/api/upgrade/v1alpha1/upgrade_spec.go
+++ b/api/upgrade/v1alpha1/upgrade_spec.go
@@ -65,6 +65,17 @@ type WaitForCompletionSpec struct {
 
 // PodDeletionSpec describes configuration for deletion of pods using special resources during automatic upgrade
 type PodDeletionSpec struct {
+	// PodSelector specifies an additional label selector for pods to evict during
+	// the upgrade. It is OR'd with the pod deletion filter provided by the
+	// consumer: a pod is evicted if the filter selects it or it matches this
+	// selector. Use it to evict GPU consumers the filter does not select, for
+	// example pods that access the GPU through a runtime class without requesting
+	// a GPU resource. Only Running and Pending pods are matched. An empty or
+	// whitespace-only selector preserves the previous behavior.
+	// For more details on label selectors, see:
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+	// +optional
+	PodSelector string `json:"podSelector,omitempty"`
 	// Force indicates if force deletion is allowed
 	// +optional
 	// +kubebuilder:default:=false

--- a/pkg/upgrade/pod_manager.go
+++ b/pkg/upgrade/pod_manager.go
@@ -117,6 +117,37 @@ func (m *PodManagerImpl) GetDaemonsetControllerRevisionHash(ctx context.Context,
 	return hash, nil
 }
 
+// podEvictionPredicate builds the predicate that decides whether a pod must be
+// evicted during the upgrade. A pod is selected if the consumer-provided
+// podDeletionFilter selects it, or if it matches the optional additional label
+// selector from the spec. The additional selector lets callers evict GPU
+// consumers the filter does not catch, for example pods that access the GPU
+// through a runtime class without requesting a GPU resource. An empty selector
+// preserves the previous behavior.
+func (m *PodManagerImpl) podEvictionPredicate(
+	podDeletionSpec *v1alpha1.PodDeletionSpec) (func(corev1.Pod) bool, error) {
+	var additionalSelector labels.Selector
+	if trimmed := strings.TrimSpace(podDeletionSpec.PodSelector); trimmed != "" {
+		sel, err := labels.Parse(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("invalid pod deletion podSelector %q: %w", podDeletionSpec.PodSelector, err)
+		}
+		additionalSelector = sel
+	}
+
+	return func(pod corev1.Pod) bool {
+		if m.podDeletionFilter != nil && m.podDeletionFilter(pod) {
+			return true
+		}
+		if additionalSelector != nil &&
+			(pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodPending) &&
+			additionalSelector.Matches(labels.Set(pod.Labels)) {
+			return true
+		}
+		return false
+	}, nil
+}
+
 // SchedulePodEviction receives a config for pod eviction and deletes pods for each node in the list.
 // The set of pods to delete is determined by a filter that is provided to the PodManagerImpl during construction.
 func (m *PodManagerImpl) SchedulePodEviction(ctx context.Context, config *PodManagerConfig) error {
@@ -133,11 +164,19 @@ func (m *PodManagerImpl) SchedulePodEviction(ctx context.Context, config *PodMan
 		return fmt.Errorf("pod deletion spec should not be empty")
 	}
 
+	// shouldDelete reports whether a pod must be evicted during the upgrade. It
+	// is used both for the pre-count and for the drain helper filter so the two
+	// stay consistent (a mismatch between them is treated as "cannot delete all
+	// required pods").
+	shouldDelete, err := m.podEvictionPredicate(podDeletionSpec)
+	if err != nil {
+		return err
+	}
+
 	// Create a custom drain filter which will be passed to the drain helper.
 	// The drain helper will carry out the actual deletion of pods on a node.
 	customDrainFilter := func(pod corev1.Pod) drain.PodDeleteStatus {
-		deleteFunc := m.podDeletionFilter(pod)
-		if !deleteFunc {
+		if !shouldDelete(pod) {
 			return drain.MakePodDeleteStatusSkip()
 		}
 		return drain.MakePodDeleteStatusOkay()
@@ -173,10 +212,10 @@ func (m *PodManagerImpl) SchedulePodEviction(ctx context.Context, config *PodMan
 					return
 				}
 
-				// Get number of pods requiring deletion using the podDeletionFilter
+				// Get number of pods requiring deletion using the combined predicate
 				numPodsToDelete := 0
 				for _, pod := range podList.Items {
-					if m.podDeletionFilter(pod) {
+					if shouldDelete(pod) {
 						numPodsToDelete++
 					}
 				}

--- a/pkg/upgrade/pod_manager_test.go
+++ b/pkg/upgrade/pod_manager_test.go
@@ -264,6 +264,227 @@ var _ = Describe("PodManager", func() {
 			Expect(node.Labels[upgrade.GetUpgradeStateLabelKey()]).To(Equal(upgrade.UpgradeStatePodRestartRequired))
 		})
 
+		It("should ignore pod labels when no podSelector is set (backward compatible)", func() {
+			gpuPods = []*corev1.Pod{
+				NewPod(fmt.Sprintf("gpu-pod-%s", id), namespace.Name, node.Name).WithResource("nvidia.com/gpu", "1").Create(),
+			}
+			// Labelled non-GPU pod that WOULD match a selector, but none is set.
+			labelledPod := NewPod(fmt.Sprintf("labelled-pod-%s", id), namespace.Name, node.Name).
+				WithLabels(map[string]string{"nvidia.com/gpu-driver-upgrade-evict": "true"}).Create()
+
+			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
+			err := provider.ChangeNodeUpgradeState(testCtx, node, upgrade.UpgradeStatePodDeletionRequired)
+			Expect(err).To(Succeed())
+
+			podManagerConfig.DeletionSpec.Force = true
+			// PodSelector intentionally left empty.
+			manager := upgrade.NewPodManager(k8sInterface, provider, log, gpuPodSpecFilter, eventRecorder)
+			err = manager.SchedulePodEviction(testCtx, &podManagerConfig)
+			Expect(err).To(Succeed())
+
+			// Only the gpu pod is evicted; the labelled non-gpu pod and cpu pod remain.
+			Eventually(func() int {
+				podList, err := k8sInterface.CoreV1().Pods(namespace.Name).List(testCtx, metav1.ListOptions{})
+				Expect(err).To(Succeed())
+				return len(podList.Items)
+			}, "5s", "100ms").Should(Equal(len(cpuPods) + 1))
+			Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: labelledPod.Name, Namespace: namespace.Name}, labelledPod)).To(Succeed())
+		})
+
+		It("should delete pods matching the additional podSelector that do not request a GPU,"+
+			" alongside gpu pods", func() {
+			gpuPods = []*corev1.Pod{
+				NewPod(fmt.Sprintf("gpu-pod-%s", id), namespace.Name, node.Name).WithResource("nvidia.com/gpu", "1").Create(),
+			}
+			// Runtime-direct consumer: no nvidia.com/gpu request, so the injected
+			// gpuPodSpecFilter does not select it. It is reached only via the
+			// additional podSelector.
+			selectorPod := NewPod(fmt.Sprintf("runtime-gpu-pod-%s", id), namespace.Name, node.Name).
+				WithLabels(map[string]string{"nvidia.com/gpu-driver-upgrade-evict": "true"}).Create()
+
+			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
+			err := provider.ChangeNodeUpgradeState(testCtx, node, upgrade.UpgradeStatePodDeletionRequired)
+			Expect(err).To(Succeed())
+
+			podManagerConfig.DeletionSpec.Force = true
+			podManagerConfig.DeletionSpec.PodSelector = "nvidia.com/gpu-driver-upgrade-evict=true"
+			manager := upgrade.NewPodManager(k8sInterface, provider, log, gpuPodSpecFilter, eventRecorder)
+			err = manager.SchedulePodEviction(testCtx, &podManagerConfig)
+			Expect(err).To(Succeed())
+
+			// Only the unrelated cpu pod should remain.
+			Eventually(func() int {
+				podList, err := k8sInterface.CoreV1().Pods(namespace.Name).List(testCtx, metav1.ListOptions{})
+				Expect(err).To(Succeed())
+				return len(podList.Items)
+			}, "5s", "100ms").Should(Equal(len(cpuPods)))
+
+			// The selector-matched pod is evicted even though it requests no GPU.
+			Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: selectorPod.Name, Namespace: namespace.Name}, selectorPod)).NotTo(Succeed())
+
+			node, err = provider.GetNode(testCtx, node.Name)
+			Expect(err).To(Succeed())
+			Expect(node.Labels[upgrade.GetUpgradeStateLabelKey()]).To(Equal(upgrade.UpgradeStatePodRestartRequired))
+		})
+
+		It("should delete a pod that both requests a GPU and matches the podSelector,"+
+			" without a count mismatch", func() {
+			gpuPods = []*corev1.Pod{
+				// Matches BOTH the gpu resource filter and the selector.
+				NewPod(fmt.Sprintf("gpu-and-label-%s", id), namespace.Name, node.Name).
+					WithResource("nvidia.com/gpu", "1").
+					WithLabels(map[string]string{"nvidia.com/gpu-driver-upgrade-evict": "true"}).Create(),
+				// Matches the selector only.
+				NewPod(fmt.Sprintf("label-only-%s", id), namespace.Name, node.Name).
+					WithLabels(map[string]string{"nvidia.com/gpu-driver-upgrade-evict": "true"}).Create(),
+			}
+
+			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
+			err := provider.ChangeNodeUpgradeState(testCtx, node, upgrade.UpgradeStatePodDeletionRequired)
+			Expect(err).To(Succeed())
+
+			podManagerConfig.DeletionSpec.Force = true
+			podManagerConfig.DeletionSpec.PodSelector = "nvidia.com/gpu-driver-upgrade-evict=true"
+			manager := upgrade.NewPodManager(k8sInterface, provider, log, gpuPodSpecFilter, eventRecorder)
+			err = manager.SchedulePodEviction(testCtx, &podManagerConfig)
+			Expect(err).To(Succeed())
+
+			// Both pods evicted; the overlap pod is not double counted (which would
+			// otherwise trip the "cannot delete all required pods" path).
+			Eventually(func() int {
+				podList, err := k8sInterface.CoreV1().Pods(namespace.Name).List(testCtx, metav1.ListOptions{})
+				Expect(err).To(Succeed())
+				return len(podList.Items)
+			}, "5s", "100ms").Should(Equal(len(cpuPods)))
+
+			node, err = provider.GetNode(testCtx, node.Name)
+			Expect(err).To(Succeed())
+			Expect(node.Labels[upgrade.GetUpgradeStateLabelKey()]).To(Equal(upgrade.UpgradeStatePodRestartRequired))
+		})
+
+		It("should not delete pods that neither request a GPU nor match the podSelector", func() {
+			// A labelled non-GPU pod that does NOT match the configured selector
+			// must be left alone.
+			keepPod := NewPod(fmt.Sprintf("keep-pod-%s", id), namespace.Name, node.Name).
+				WithLabels(map[string]string{"app": "unrelated"}).Create()
+			// A pod with no labels at all must also be left alone by a positive selector.
+			barePod := NewPod(fmt.Sprintf("bare-pod-%s", id), namespace.Name, node.Name).Create()
+
+			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
+			err := provider.ChangeNodeUpgradeState(testCtx, node, upgrade.UpgradeStatePodDeletionRequired)
+			Expect(err).To(Succeed())
+
+			podManagerConfig.DeletionSpec.Force = true
+			podManagerConfig.DeletionSpec.PodSelector = "nvidia.com/gpu-driver-upgrade-evict=true"
+			manager := upgrade.NewPodManager(k8sInterface, provider, log, gpuPodSpecFilter, eventRecorder)
+			err = manager.SchedulePodEviction(testCtx, &podManagerConfig)
+			Expect(err).To(Succeed())
+
+			// No pod matches, so the node proceeds and every pod survives.
+			Eventually(func() string {
+				n, err := provider.GetNode(testCtx, node.Name)
+				Expect(err).To(Succeed())
+				return n.Labels[upgrade.GetUpgradeStateLabelKey()]
+			}, "5s", "100ms").Should(Equal(upgrade.UpgradeStatePodRestartRequired))
+
+			podList, err := k8sInterface.CoreV1().Pods(namespace.Name).List(testCtx, metav1.ListOptions{})
+			Expect(err).To(Succeed())
+			Expect(podList.Items).To(HaveLen(len(cpuPods) + 2))
+			Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: keepPod.Name, Namespace: namespace.Name}, keepPod)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: barePod.Name, Namespace: namespace.Name}, barePod)).To(Succeed())
+		})
+
+		It("should not evict a podSelector-matched pod that has already completed", func() {
+			// A Succeeded pod matches the label but is excluded by the phase guard,
+			// mirroring how the GPU Operator's own filter only considers
+			// Running/Pending pods.
+			donePod := NewPod(fmt.Sprintf("done-pod-%s", id), namespace.Name, node.Name).
+				WithLabels(map[string]string{"nvidia.com/gpu-driver-upgrade-evict": "true"}).Create()
+			donePod.Status.Phase = corev1.PodSucceeded
+			Expect(updatePodStatus(donePod)).To(Succeed())
+
+			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
+			err := provider.ChangeNodeUpgradeState(testCtx, node, upgrade.UpgradeStatePodDeletionRequired)
+			Expect(err).To(Succeed())
+
+			podManagerConfig.DeletionSpec.Force = true
+			podManagerConfig.DeletionSpec.PodSelector = "nvidia.com/gpu-driver-upgrade-evict=true"
+			manager := upgrade.NewPodManager(k8sInterface, provider, log, gpuPodSpecFilter, eventRecorder)
+			err = manager.SchedulePodEviction(testCtx, &podManagerConfig)
+			Expect(err).To(Succeed())
+
+			Eventually(func() string {
+				n, err := provider.GetNode(testCtx, node.Name)
+				Expect(err).To(Succeed())
+				return n.Labels[upgrade.GetUpgradeStateLabelKey()]
+			}, "5s", "100ms").Should(Equal(upgrade.UpgradeStatePodRestartRequired))
+			Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: donePod.Name, Namespace: namespace.Name}, donePod)).To(Succeed())
+		})
+
+		It("should move the node to drain-required when a podSelector-matched pod cannot be"+
+			" force-deleted", func() {
+			// Standalone (unreplicated) labelled pod. Without Force the drain helper
+			// refuses it, so the pre-count and the deletable count disagree and the
+			// node falls back to drain. This proves selector-matched pods take part
+			// in the same consistency invariant as filter-matched pods.
+			NewPod(fmt.Sprintf("runtime-gpu-pod-%s", id), namespace.Name, node.Name).
+				WithLabels(map[string]string{"nvidia.com/gpu-driver-upgrade-evict": "true"}).Create()
+
+			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
+			err := provider.ChangeNodeUpgradeState(testCtx, node, upgrade.UpgradeStatePodDeletionRequired)
+			Expect(err).To(Succeed())
+
+			podManagerConfig.DeletionSpec.PodSelector = "nvidia.com/gpu-driver-upgrade-evict=true"
+			podManagerConfig.DrainEnabled = true
+			manager := upgrade.NewPodManager(k8sInterface, provider, log, gpuPodSpecFilter, eventRecorder)
+			err = manager.SchedulePodEviction(testCtx, &podManagerConfig)
+			Expect(err).To(Succeed())
+
+			Eventually(func() string {
+				n, err := provider.GetNode(testCtx, node.Name)
+				Expect(err).To(Succeed())
+				return n.Labels[upgrade.GetUpgradeStateLabelKey()]
+			}, "5s", "100ms").Should(Equal(upgrade.UpgradeStateDrainRequired))
+		})
+
+		It("should treat a whitespace-only podSelector as empty", func() {
+			gpuPods = []*corev1.Pod{
+				NewPod(fmt.Sprintf("gpu-pod-%s", id), namespace.Name, node.Name).WithResource("nvidia.com/gpu", "1").Create(),
+			}
+			labelledPod := NewPod(fmt.Sprintf("labelled-pod-%s", id), namespace.Name, node.Name).
+				WithLabels(map[string]string{"nvidia.com/gpu-driver-upgrade-evict": "true"}).Create()
+
+			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
+			err := provider.ChangeNodeUpgradeState(testCtx, node, upgrade.UpgradeStatePodDeletionRequired)
+			Expect(err).To(Succeed())
+
+			podManagerConfig.DeletionSpec.Force = true
+			// Whitespace-only selector must NOT be parsed as a match-everything selector.
+			podManagerConfig.DeletionSpec.PodSelector = "   "
+			manager := upgrade.NewPodManager(k8sInterface, provider, log, gpuPodSpecFilter, eventRecorder)
+			err = manager.SchedulePodEviction(testCtx, &podManagerConfig)
+			Expect(err).To(Succeed())
+
+			// Only the gpu pod is evicted; the labelled non-gpu pod is not swept up.
+			Eventually(func() int {
+				podList, err := k8sInterface.CoreV1().Pods(namespace.Name).List(testCtx, metav1.ListOptions{})
+				Expect(err).To(Succeed())
+				return len(podList.Items)
+			}, "5s", "100ms").Should(Equal(len(cpuPods) + 1))
+			Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: labelledPod.Name, Namespace: namespace.Name}, labelledPod)).To(Succeed())
+		})
+
+		It("should return an error when the additional podSelector is invalid", func() {
+			provider := upgrade.NewNodeUpgradeStateProvider(k8sClient, log, eventRecorder)
+			err := provider.ChangeNodeUpgradeState(testCtx, node, upgrade.UpgradeStatePodDeletionRequired)
+			Expect(err).To(Succeed())
+
+			podManagerConfig.DeletionSpec.PodSelector = "invalid selector"
+			manager := upgrade.NewPodManager(k8sInterface, provider, log, gpuPodSpecFilter, eventRecorder)
+			err = manager.SchedulePodEviction(testCtx, &podManagerConfig)
+			Expect(err).To(HaveOccurred())
+		})
+
 		It("should fail to delete all standalone gpu pods without force,"+
 			" and node should be moved to UpgradeStateFailed when drain is disabled", func() {
 			gpuPods = []*corev1.Pod{


### PR DESCRIPTION
The driver upgrade pod-deletion path only evicts pods selected by the consumer-provided PodDeletionFilter (in the GPU Operator, pods that request an nvidia.com/gpu resource). GPU consumers that access the device through a runtime class without a resource request, as well as other declared workloads, are never evicted, so the kernel module stays pinned and an in-place driver upgrade stalls.

Add an optional PodSelector to PodDeletionSpec. A pod is evicted if the injected filter selects it or it matches the selector. The combined predicate is applied to both the pre-count and the drain helper filter so the two stay consistent. An empty selector preserves the previous behavior.

Refs: NVIDIA/gpu-operator#2570